### PR TITLE
Standardize page styling to match dashboard

### DIFF
--- a/caskr.client/src/App.tsx
+++ b/caskr.client/src/App.tsx
@@ -21,8 +21,8 @@ function App() {
         <Route path='statuses' element={<StatusesPage />} />
         <Route path='users' element={<UsersPage />} />
         <Route path='usertypes' element={<UserTypesPage />} />
+        <Route path='login' element={<LoginPage />} />
       </Route>
-      <Route path='/login' element={<LoginPage />} />
     </Routes>
   )
 }

--- a/caskr.client/src/pages/BarrelsPage.tsx
+++ b/caskr.client/src/pages/BarrelsPage.tsx
@@ -25,59 +25,75 @@ function BarrelsPage() {
   }
 
   return (
-    <div>
-      <h1>Barrels</h1>
-      <button onClick={() => setShowModal(true)}>Forecasting</button>
-
-      {showModal && (
-        <div className='modal'>
-          <form onSubmit={handleForecast}>
-            <label>
-              Date:
-              <input type='date' value={targetDate} onChange={e => setTargetDate(e.target.value)} />
-            </label>
-            <label>
-              Age Statement:
-              <input
-                value={ageStatement}
-                onChange={e => setAgeStatement(e.target.value)}
-                placeholder='e.g. 5 years'
-              />
-            </label>
-            <button type='submit'>Submit</button>
-            <button type='button' onClick={() => setShowModal(false)}>Cancel</button>
-          </form>
+    <>
+      <section className='content-section'>
+        <div className='section-header'>
+          <h2 className='section-title'>Barrels</h2>
+          <button onClick={() => setShowModal(true)}>Forecasting</button>
         </div>
-      )}
-
-      <table className='table'>
-        <thead>
-          <tr>
-            <th>SKU</th>
-            <th>Order</th>
-          </tr>
-        </thead>
-        <tbody>
-          {barrels.map(b => (
-            <tr key={b.id}>
-              <td>{b.sku}</td>
-              <td>{b.orderId}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-
+        {showModal && (
+          <div className='modal'>
+            <form onSubmit={handleForecast}>
+              <label>
+                Date:
+                <input type='date' value={targetDate} onChange={e => setTargetDate(e.target.value)} />
+              </label>
+              <label>
+                Age Statement:
+                <input
+                  value={ageStatement}
+                  onChange={e => setAgeStatement(e.target.value)}
+                  placeholder='e.g. 5 years'
+                />
+              </label>
+              <button type='submit'>Submit</button>
+              <button type='button' onClick={() => setShowModal(false)}>Cancel</button>
+            </form>
+          </div>
+        )}
+        <div className='table-container'>
+          <table className='table'>
+            <thead>
+              <tr>
+                <th>SKU</th>
+                <th>Order</th>
+              </tr>
+            </thead>
+            <tbody>
+              {barrels.map(b => (
+                <tr key={b.id}>
+                  <td>{b.sku}</td>
+                  <td>{b.orderId}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
       {forecast.length > 0 && (
-        <div>
-          <h2>Forecast Result (Total: {forecastCount})</h2>
-          <ul>
-            {forecast.map(b => (
-              <li key={b.id}>{b.sku}</li>
-            ))}
-          </ul>
-        </div>
+        <section className='content-section'>
+          <div className='section-header'>
+            <h2 className='section-title'>Forecast Result (Total: {forecastCount})</h2>
+          </div>
+          <div className='table-container'>
+            <table className='table'>
+              <thead>
+                <tr>
+                  <th>SKU</th>
+                </tr>
+              </thead>
+              <tbody>
+                {forecast.map(b => (
+                  <tr key={b.id}>
+                    <td>{b.sku}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
       )}
-    </div>
+    </>
   )
 }
 

--- a/caskr.client/src/pages/LoginPage.tsx
+++ b/caskr.client/src/pages/LoginPage.tsx
@@ -23,14 +23,16 @@ function LoginPage() {
   }
 
   return (
-    <div>
-      <h1>Login</h1>
+    <section className='content-section'>
+      <div className='section-header'>
+        <h2 className='section-title'>Login</h2>
+      </div>
       <form onSubmit={handleSubmit}>
         <input value={email} onChange={e => setEmail(e.target.value)} placeholder='Email' />
         <button type='submit'>Login</button>
       </form>
       {message && <p>{message}</p>}
-    </div>
+    </section>
   )
 }
 

--- a/caskr.client/src/pages/OrdersPage.tsx
+++ b/caskr.client/src/pages/OrdersPage.tsx
@@ -61,8 +61,10 @@ function OrdersPage() {
   }
 
   return (
-    <div>
-      <h1>Orders</h1>
+    <section className='content-section'>
+      <div className='section-header'>
+        <h2 className='section-title'>Orders</h2>
+      </div>
       <form onSubmit={handleAdd}>
         <input value={newName} onChange={e => setNewName(e.target.value)} placeholder='Name' />
         <select value={newStatus} onChange={e => setNewStatus(Number(e.target.value))}>
@@ -72,53 +74,55 @@ function OrdersPage() {
         </select>
         <button type='submit'>Add</button>
       </form>
-      <table className='table'>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Status</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {orders.map(o => (
-            <tr key={o.id}>
-              <td>
-                {editing === o.id ? (
-                  <input value={editName} onChange={e => setEditName(e.target.value)} />
-                ) : (
-                  o.name
-                )}
-              </td>
-              <td>
-                {editing === o.id ? (
-                  <select value={editStatus} onChange={e => setEditStatus(Number(e.target.value))}>
-                    {statuses.map(s => (
-                      <option key={s.id} value={s.id}>{s.name}</option>
-                    ))}
-                  </select>
-                ) : (
-                  getStatusName(o.statusId)
-                )}
-              </td>
-              <td>
-                {editing === o.id ? (
-                  <>
-                    <button onClick={() => handleUpdate(o.id)}>Save</button>
-                    <button onClick={() => setEditing(null)}>Cancel</button>
-                  </>
-                ) : (
-                  <>
-                    <button onClick={() => startEdit(o)}>Edit</button>
-                    <button onClick={() => dispatch(deleteOrder(o.id))}>Delete</button>
-                  </>
-                )}
-              </td>
+      <div className='table-container'>
+        <table className='table'>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Status</th>
+              <th>Actions</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+          </thead>
+          <tbody>
+            {orders.map(o => (
+              <tr key={o.id}>
+                <td>
+                  {editing === o.id ? (
+                    <input value={editName} onChange={e => setEditName(e.target.value)} />
+                  ) : (
+                    o.name
+                  )}
+                </td>
+                <td>
+                  {editing === o.id ? (
+                    <select value={editStatus} onChange={e => setEditStatus(Number(e.target.value))}>
+                      {statuses.map(s => (
+                        <option key={s.id} value={s.id}>{s.name}</option>
+                      ))}
+                    </select>
+                  ) : (
+                    getStatusName(o.statusId)
+                  )}
+                </td>
+                <td>
+                  {editing === o.id ? (
+                    <>
+                      <button onClick={() => handleUpdate(o.id)}>Save</button>
+                      <button onClick={() => setEditing(null)}>Cancel</button>
+                    </>
+                  ) : (
+                    <>
+                      <button onClick={() => startEdit(o)}>Edit</button>
+                      <button onClick={() => dispatch(deleteOrder(o.id))}>Delete</button>
+                    </>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
   )
 }
 

--- a/caskr.client/src/pages/ProductsPage.tsx
+++ b/caskr.client/src/pages/ProductsPage.tsx
@@ -41,52 +41,56 @@ function ProductsPage() {
   }
 
   return (
-    <div>
-      <h1>Products</h1>
+    <section className='content-section'>
+      <div className='section-header'>
+        <h2 className='section-title'>Products</h2>
+      </div>
       <form onSubmit={handleAdd}>
         <input type='number' value={newOwner} onChange={e => setNewOwner(Number(e.target.value))} placeholder='Owner ID' />
         <input value={newNotes} onChange={e => setNewNotes(e.target.value)} placeholder='Notes' />
         <button type='submit'>Add</button>
       </form>
-      <table className='table'>
-        <thead>
-          <tr><th>OwnerId</th><th>Notes</th><th>Actions</th></tr>
-        </thead>
-        <tbody>
-          {products.map(p => (
-            <tr key={p.id}>
-              <td>
-                {editing === p.id ? (
-                  <input type='number' value={editOwner} onChange={e => setEditOwner(Number(e.target.value))} />
-                ) : (
-                  p.ownerId
-                )}
-              </td>
-              <td>
-                {editing === p.id ? (
-                  <input value={editNotes} onChange={e => setEditNotes(e.target.value)} />
-                ) : (
-                  p.notes
-                )}
-              </td>
-              <td>
-                {editing === p.id ? (
-                  <>
-                    <button onClick={() => handleUpdate(p.id)}>Save</button>
-                    <button onClick={() => setEditing(null)}>Cancel</button>
-                  </>
-                ) : (
-                  <>
-                    <button onClick={() => startEdit(p)}>Edit</button>
-                    <button onClick={() => dispatch(deleteProduct(p.id))}>Delete</button>
-                  </>
-                )}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+      <div className='table-container'>
+        <table className='table'>
+          <thead>
+            <tr><th>OwnerId</th><th>Notes</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            {products.map(p => (
+              <tr key={p.id}>
+                <td>
+                  {editing === p.id ? (
+                    <input type='number' value={editOwner} onChange={e => setEditOwner(Number(e.target.value))} />
+                  ) : (
+                    p.ownerId
+                  )}
+                </td>
+                <td>
+                  {editing === p.id ? (
+                    <input value={editNotes} onChange={e => setEditNotes(e.target.value)} />
+                  ) : (
+                    p.notes
+                  )}
+                </td>
+                <td>
+                  {editing === p.id ? (
+                    <>
+                      <button onClick={() => handleUpdate(p.id)}>Save</button>
+                      <button onClick={() => setEditing(null)}>Cancel</button>
+                    </>
+                  ) : (
+                    <>
+                      <button onClick={() => startEdit(p)}>Edit</button>
+                      <button onClick={() => dispatch(deleteProduct(p.id))}>Delete</button>
+                    </>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
   )
 }
 

--- a/caskr.client/src/pages/StatusesPage.tsx
+++ b/caskr.client/src/pages/StatusesPage.tsx
@@ -34,32 +34,48 @@ function StatusesPage() {
   }
 
   return (
-    <div>
-      <h1>Statuses</h1>
+    <section className='content-section'>
+      <div className='section-header'>
+        <h2 className='section-title'>Statuses</h2>
+      </div>
       <form onSubmit={handleAdd}>
-        <input value={newName} onChange={e => setNewName(e.target.value)} placeholder='Name'/>
+        <input value={newName} onChange={e => setNewName(e.target.value)} placeholder='Name' />
         <button type='submit'>Add</button>
       </form>
-      <ul>
-        {statuses.map(s => (
-          <li key={s.id}>
-            {editing === s.id ? (
-              <>
-                <input value={editName} onChange={e => setEditName(e.target.value)} />
-                <button onClick={() => handleUpdate(s.id)}>Save</button>
-                <button onClick={() => setEditing(null)}>Cancel</button>
-              </>
-            ) : (
-              <>
-                {s.name}
-                <button onClick={() => startEdit(s)}>Edit</button>
-                <button onClick={() => dispatch(deleteStatus(s.id))}>Delete</button>
-              </>
-            )}
-          </li>
-        ))}
-      </ul>
-    </div>
+      <div className='table-container'>
+        <table className='table'>
+          <thead>
+            <tr><th>Name</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            {statuses.map(s => (
+              <tr key={s.id}>
+                <td>
+                  {editing === s.id ? (
+                    <input value={editName} onChange={e => setEditName(e.target.value)} />
+                  ) : (
+                    s.name
+                  )}
+                </td>
+                <td>
+                  {editing === s.id ? (
+                    <>
+                      <button onClick={() => handleUpdate(s.id)}>Save</button>
+                      <button onClick={() => setEditing(null)}>Cancel</button>
+                    </>
+                  ) : (
+                    <>
+                      <button onClick={() => startEdit(s)}>Edit</button>
+                      <button onClick={() => dispatch(deleteStatus(s.id))}>Delete</button>
+                    </>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
   )
 }
 

--- a/caskr.client/src/pages/UserTypesPage.tsx
+++ b/caskr.client/src/pages/UserTypesPage.tsx
@@ -34,32 +34,48 @@ function UserTypesPage() {
   }
 
   return (
-    <div>
-      <h1>User Types</h1>
+    <section className='content-section'>
+      <div className='section-header'>
+        <h2 className='section-title'>User Types</h2>
+      </div>
       <form onSubmit={handleAdd}>
         <input value={newName} onChange={e => setNewName(e.target.value)} placeholder='Name'/>
         <button type='submit'>Add</button>
       </form>
-      <ul>
-        {userTypes.map(ut => (
-          <li key={ut.id}>
-            {editing === ut.id ? (
-              <>
-                <input value={editName} onChange={e => setEditName(e.target.value)} />
-                <button onClick={() => handleUpdate(ut.id)}>Save</button>
-                <button onClick={() => setEditing(null)}>Cancel</button>
-              </>
-            ) : (
-              <>
-                {ut.name}
-                <button onClick={() => startEdit(ut)}>Edit</button>
-                <button onClick={() => dispatch(deleteUserType(ut.id))}>Delete</button>
-              </>
-            )}
-          </li>
-        ))}
-      </ul>
-    </div>
+      <div className='table-container'>
+        <table className='table'>
+          <thead>
+            <tr><th>Name</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            {userTypes.map(ut => (
+              <tr key={ut.id}>
+                <td>
+                  {editing === ut.id ? (
+                    <input value={editName} onChange={e => setEditName(e.target.value)} />
+                  ) : (
+                    ut.name
+                  )}
+                </td>
+                <td>
+                  {editing === ut.id ? (
+                    <>
+                      <button onClick={() => handleUpdate(ut.id)}>Save</button>
+                      <button onClick={() => setEditing(null)}>Cancel</button>
+                    </>
+                  ) : (
+                    <>
+                      <button onClick={() => startEdit(ut)}>Edit</button>
+                      <button onClick={() => dispatch(deleteUserType(ut.id))}>Delete</button>
+                    </>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
   )
 }
 

--- a/caskr.client/src/pages/UsersPage.tsx
+++ b/caskr.client/src/pages/UsersPage.tsx
@@ -60,8 +60,10 @@ function UsersPage() {
   const typeName = (id: number) => userTypes.find(t => t.id === id)?.name || id
 
   return (
-    <div>
-      <h1>Users</h1>
+    <section className='content-section'>
+      <div className='section-header'>
+        <h2 className='section-title'>Users</h2>
+      </div>
       <form onSubmit={handleAdd}>
         <input value={newName} onChange={e => setNewName(e.target.value)} placeholder='Name'/>
         <input value={newEmail} onChange={e => setNewEmail(e.target.value)} placeholder='Email'/>
@@ -71,54 +73,56 @@ function UsersPage() {
         </select>
         <button type='submit'>Create User</button>
       </form>
-      <table className='table'>
-        <thead>
-          <tr><th>Name</th><th>Email</th><th>Type</th><th>Actions</th></tr>
-        </thead>
-        <tbody>
-          {users.map(u => (
-            <tr key={u.id}>
-              <td>
-                {editing === u.id ? (
-                  <input value={editName} onChange={e => setEditName(e.target.value)} />
-                ) : (
-                  u.name
-                )}
-              </td>
-              <td>
-                {editing === u.id ? (
-                  <input value={editEmail} onChange={e => setEditEmail(e.target.value)} />
-                ) : (
-                  u.email
-                )}
-              </td>
-              <td>
-                {editing === u.id ? (
-                  <select value={editType} onChange={e => setEditType(Number(e.target.value))}>
-                    {userTypes.map(t => <option key={t.id} value={t.id}>{t.name}</option>)}
-                  </select>
-                ) : (
-                  typeName(u.userTypeId)
-                )}
-              </td>
-              <td>
-                {editing === u.id ? (
-                  <>
-                    <button onClick={() => handleUpdate(u.id)}>Save</button>
-                    <button onClick={() => setEditing(null)}>Cancel</button>
-                  </>
-                ) : (
-                  <>
-                    <button onClick={() => startEdit(u)}>Edit</button>
-                    <button onClick={() => dispatch(deleteUser(u.id))}>Delete</button>
-                  </>
-                )}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+      <div className='table-container'>
+        <table className='table'>
+          <thead>
+            <tr><th>Name</th><th>Email</th><th>Type</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            {users.map(u => (
+              <tr key={u.id}>
+                <td>
+                  {editing === u.id ? (
+                    <input value={editName} onChange={e => setEditName(e.target.value)} />
+                  ) : (
+                    u.name
+                  )}
+                </td>
+                <td>
+                  {editing === u.id ? (
+                    <input value={editEmail} onChange={e => setEditEmail(e.target.value)} />
+                  ) : (
+                    u.email
+                  )}
+                </td>
+                <td>
+                  {editing === u.id ? (
+                    <select value={editType} onChange={e => setEditType(Number(e.target.value))}>
+                      {userTypes.map(t => <option key={t.id} value={t.id}>{t.name}</option>)}
+                    </select>
+                  ) : (
+                    typeName(u.userTypeId)
+                  )}
+                </td>
+                <td>
+                  {editing === u.id ? (
+                    <>
+                      <button onClick={() => handleUpdate(u.id)}>Save</button>
+                      <button onClick={() => setEditing(null)}>Cancel</button>
+                    </>
+                  ) : (
+                    <>
+                      <button onClick={() => startEdit(u)}>Edit</button>
+                      <button onClick={() => dispatch(deleteUser(u.id))}>Delete</button>
+                    </>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
   )
 }
 


### PR DESCRIPTION
## Summary
- Align login route with main layout
- Wrap orders, barrels, products, statuses, users and user type pages in dashboard-style content sections
- Give login page consistent styling with the rest of the app

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68bf6cc97b6c832bafe1819d925e9acc