### PR TITLE
Add Playwright end-to-end tests for client

### DIFF
--- a/caskr.client/package-lock.json
+++ b/caskr.client/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@playwright/test": "^1.48.2",
         "@types/node": "^22.10.2",
         "@types/react": "^18.3.17",
         "@types/react-dom": "^18.3.5",
@@ -961,6 +962,21 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -2587,6 +2603,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/caskr.client/package.json
+++ b/caskr.client/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "playwright test"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.2.2",
@@ -28,6 +29,7 @@
     "globals": "^15.13.0",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.1",
-    "vite": "^6.0.3"
+    "vite": "^6.0.3",
+    "@playwright/test": "^1.48.2"
   }
 }

--- a/caskr.client/playwright.config.ts
+++ b/caskr.client/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  webServer: {
+    command: 'npm run dev -- --port 51844',
+    url: 'http://localhost:51844',
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+    env: {
+      VITE_USE_HTTPS: 'false',
+    }
+  },
+  use: {
+    baseURL: 'http://localhost:51844',
+    headless: true,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/caskr.client/tests/home.spec.ts
+++ b/caskr.client/tests/home.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('home page has CASKr header and orders link', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveTitle(/Caskr Orders/);
+  await expect(page.getByRole('link', { name: 'Orders' })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add Playwright test runner and configuration for the client
- allow Vite dev server to run without HTTPS certificates in tests
- create sample home page test verifying navigation link

## Testing
- `npm test`
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68bf6ee68310832b9cf1d8da28846497