### PR TITLE
Add comprehensive frontend tests and enforce running all tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Instructions for Contributors
 
-All changes must ensure the .NET solution builds and the tests pass.
+All changes must ensure the .NET solution builds and **all tests run and pass**.
 
 Before committing, run:
 
@@ -8,8 +8,10 @@ Before committing, run:
 dotnet restore
 # build without restoring again
 dotnet build --no-restore
-# run tests without building again
+# run server tests without building again
 dotnet test --no-build
+# run client tests (requires Google Chrome)
+npm --prefix caskr.client test
 ```
 
 If any command fails, fix the issues before committing.

--- a/caskr.client/playwright.config.ts
+++ b/caskr.client/playwright.config.ts
@@ -18,8 +18,8 @@ export default defineConfig({
   },
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: 'chrome',
+      use: { ...devices['Desktop Chrome'], channel: 'chrome', launchOptions: { args: ['--no-sandbox'] } },
     },
   ],
 });

--- a/caskr.client/tests/login.spec.ts
+++ b/caskr.client/tests/login.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('login', () => {
+  test('shows error on failed login', async ({ page }) => {
+    await page.route('**/api/auth/login', route =>
+      route.fulfill({ status: 401, contentType: 'application/json', body: '{}' })
+    );
+    await page.goto('/login');
+    await page.fill('input[placeholder="Email"]', 'test@example.com');
+    await page.click('button[type="submit"]');
+    await expect(page.getByText('Login failed')).toBeVisible();
+  });
+
+  test('stores token and redirects on successful login', async ({ page }) => {
+    await page.route('**/api/auth/login', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ token: 'fake-token' })
+      })
+    );
+    await page.goto('/login');
+    await page.fill('input[placeholder="Email"]', 'test@example.com');
+    await page.click('button[type="submit"]');
+    await expect(page).toHaveURL(/\/landing$/);
+    const token = await page.evaluate(() => localStorage.getItem('token'));
+    expect(token).toBe('fake-token');
+  });
+});

--- a/caskr.client/tests/navigation.spec.ts
+++ b/caskr.client/tests/navigation.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('navigation links', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/**', async route => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+      } else {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+      }
+    });
+  });
+
+  const pages = [
+    { link: 'Orders', heading: 'Orders' },
+    { link: 'Barrels', heading: 'Barrels' },
+    { link: 'Products', heading: 'Products' },
+    { link: 'Statuses', heading: 'Statuses' },
+    { link: 'Users', heading: 'Users' },
+    { link: 'User Types', heading: 'User Types' },
+    { link: 'Login', heading: 'Login' }
+  ];
+
+  test('each navigation link leads to correct page', async ({ page }) => {
+    await page.goto('/orders');
+    for (const p of pages) {
+      await page.getByRole('link', { name: p.link }).click();
+      await expect(page.getByRole('heading', { name: p.heading })).toBeVisible();
+    }
+  });
+});

--- a/caskr.client/tests/orders.spec.ts
+++ b/caskr.client/tests/orders.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('orders page', () => {
+  test('can add a new order', async ({ page }) => {
+    await page.route('**/api/status', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ id: 1, name: 'New', statusTasks: [] }])
+      })
+    );
+    await page.route('**/api/orders', async route => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+      } else if (route.request().method() === 'POST') {
+        const newOrder = {
+          id: 1,
+          name: 'Test Order',
+          statusId: 1,
+          ownerId: 1,
+          spiritTypeId: 1,
+          quantity: 1,
+          mashBillId: 1
+        };
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(newOrder)
+        });
+      } else {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+      }
+    });
+
+    await page.goto('/orders');
+    await page.fill('input[placeholder="Name"]', 'Test Order');
+    await page.selectOption('select', '1');
+    await page.click('button[type="submit"]');
+    await expect(page.getByText('Test Order')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- require running frontend Playwright tests with system Chrome
- configure Playwright to launch installed Chrome without sandbox
- remove browser auto-download script from client package

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`
- `npm --prefix caskr.client test`


------
https://chatgpt.com/codex/tasks/task_e_68bf726ce224832bbfb1ec5b818cc2d5