### PR TITLE
Update connection string to match local Postgres container

### DIFF
--- a/Caskr.Server.Tests/appsettings.json
+++ b/Caskr.Server.Tests/appsettings.json
@@ -7,6 +7,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "CaskrDatabaseConnectionString": "Host=172.30.128.1; Database=caskr-db; Username=postgres; Password=docker"
+    "CaskrDatabaseConnectionString": "Host=localhost; Port=5432; Database=caskr-db; Username=postgres; Password=docker"
   }
 }

--- a/Caskr.Server/appsettings.json
+++ b/Caskr.Server/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "CaskrDatabaseConnectionString": "Host=172.30.128.1; Database=caskr-db; Username=postgres; Password=docker"
+    "CaskrDatabaseConnectionString": "Host=localhost; Port=5432; Database=caskr-db; Username=postgres; Password=docker"
   },
   "SendGrid": {
     "ApiKey": "test-api-key",


### PR DESCRIPTION
## Summary
- update the server and test appsettings files to target the dockerized Postgres instance via localhost and its exposed port

## Testing
- dotnet restore *(fails: command not found in environment)*
- npm --prefix caskr.client test *(fails: chromium distribution 'chrome' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d16d4fb624832ba487c0333a962a3c