### PR TITLE
Fix Keycloak seeding and database init path

### DIFF
--- a/Keycloak/realm-export.json
+++ b/Keycloak/realm-export.json
@@ -13,5 +13,22 @@
       "directAccessGrantsEnabled": true,
       "serviceAccountsEnabled": true
     }
+  ],
+  "users": [
+    {
+      "username": "shaw@caskr.co",
+      "email": "shaw@caskr.co",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Whiskey123!",
+          "temporary": false
+        }
+      ],
+      "requiredActions": [],
+      "groups": []
+    }
   ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - '5432:5432'
     volumes:
       - ./Database/postgres:/var/lib/postgresql/data
-      - ./initdb.d:/docker-entrypoint-initdb.d
+      - ./Database/initdb.d:/docker-entrypoint-initdb.d
 
   keycloak:
     build: ./Keycloak


### PR DESCRIPTION
## Summary
- mount the correct database seed directory so the application data, including seeded users, loads on startup
- import a default Shaw user into the Keycloak realm with a known password to enable successful logins

## Testing
- dotnet restore *(fails: dotnet CLI not installed in container)*
- npm --prefix caskr.client test *(fails: Playwright chrome browser not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d1726c8a24832b97f3d7dc82798346