### PR TITLE
Update primary contact handling

### DIFF
--- a/Caskr.Server/Models/CaskrDbContext.cs
+++ b/Caskr.Server/Models/CaskrDbContext.cs
@@ -155,16 +155,10 @@ public partial class CaskrDbContext : DbContext
                 .HasDefaultValueSql("nextval('\"Company_id_seq\"'::regclass)")
                 .HasColumnName("id");
             entity.Property(e => e.CompanyName).HasColumnName("company_name");
-            entity.Property(e => e.PrimaryContactId).HasColumnName("primary_contact_id");
             entity.Property(e => e.CreatedAt)
                 .HasDefaultValueSql("CURRENT_TIMESTAMP")
                 .HasColumnName("created_date");
             entity.Property(e => e.RenewalDate).HasColumnName("renewal_date");
-
-            entity.HasOne(d => d.PrimaryContact).WithMany()
-                .HasForeignKey(d => d.PrimaryContactId)
-                .OnDelete(DeleteBehavior.ClientSetNull)
-                .HasConstraintName("fk_company_primary_contact");
         });
 
         modelBuilder.Entity<Status>(entity =>
@@ -222,6 +216,7 @@ public partial class CaskrDbContext : DbContext
             entity.Property(e => e.Name).HasColumnName("name");
             entity.Property(e => e.UserTypeId).HasColumnName("user_type_id");
             entity.Property(e => e.CompanyId).HasColumnName("company_id");
+            entity.Property(e => e.IsPrimaryContact).HasColumnName("is_primary_contact");
 
             entity.HasOne(d => d.UserType).WithMany(p => p.Users)
                 .HasForeignKey(d => d.UserTypeId)

--- a/Caskr.Server/Models/Company.cs
+++ b/Caskr.Server/Models/Company.cs
@@ -6,8 +6,6 @@ public partial class Company
 
     public string CompanyName { get; set; } = null!;
 
-    public int PrimaryContactId { get; set; }
-
     public DateTime CreatedAt { get; set; }
 
     public DateTime RenewalDate { get; set; }
@@ -17,6 +15,4 @@ public partial class Company
     public virtual ICollection<Rickhouse> Rickhouses { get; set; } = new List<Rickhouse>();
 
     public virtual ICollection<Barrel> Barrels { get; set; } = new List<Barrel>();
-
-    public virtual User PrimaryContact { get; set; } = null!;
 }

--- a/Caskr.Server/Models/User.cs
+++ b/Caskr.Server/Models/User.cs
@@ -12,6 +12,8 @@ public partial class User
 
     public int CompanyId { get; set; }
 
+    public bool IsPrimaryContact { get; set; }
+
     [System.ComponentModel.DataAnnotations.Schema.NotMapped]
     public string CompanyName { get; set; } = string.Empty;
 

--- a/Database/initdb.d/01-schema-init.sql
+++ b/Database/initdb.d/01-schema-init.sql
@@ -243,7 +243,8 @@ CREATE TABLE public.users (
     name text NOT NULL,
     email text NOT NULL,
     user_type_id integer NOT NULL,
-    company_id integer NOT NULL
+    company_id integer NOT NULL,
+    is_primary_contact boolean DEFAULT false NOT NULL
 );
 
 
@@ -522,7 +523,6 @@ ALTER TABLE ONLY public.tasks
 CREATE TABLE public.company (
     id integer NOT NULL,
     company_name text NOT NULL,
-    primary_contact_id integer NOT NULL,
     created_date timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     renewal_date timestamp with time zone NOT NULL
 );
@@ -564,14 +564,6 @@ ALTER TABLE ONLY public.company ALTER COLUMN id SET DEFAULT nextval('public."Com
 ALTER TABLE ONLY public.company
     ADD CONSTRAINT "Company_pkey" PRIMARY KEY (id);
 
---
--- Name: company fk_company_primary_contact; Type: FK CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.company
-    ADD CONSTRAINT fk_company_primary_contact FOREIGN KEY (primary_contact_id) REFERENCES public.users(id);
-
---
 -- Name: users fk_user_company; Type: FK CONSTRAINT; Schema: public; Owner: postgres
 --
 

--- a/Database/initdb.d/02-seed-whiskey-data.sql
+++ b/Database/initdb.d/02-seed-whiskey-data.sql
@@ -48,40 +48,40 @@ INSERT INTO public.status_task (id, status_id, name) VALUES
     (20, 6, 'Product Listing');
 
 -- Companies
-INSERT INTO public.company (company_name, primary_contact_id, renewal_date) VALUES
-    ('Middle West', 3, CURRENT_TIMESTAMP + INTERVAL '1 year'),
-    ('Makers Mark', 4, CURRENT_TIMESTAMP + INTERVAL '1 year'),
-    ('Jim Beam', 2, CURRENT_TIMESTAMP + INTERVAL '1 year'),
-    ('Jack Daniels', 1, CURRENT_TIMESTAMP + INTERVAL '1 year');
+INSERT INTO public.company (company_name, renewal_date) VALUES
+    ('Middle West', CURRENT_TIMESTAMP + INTERVAL '1 year'),
+    ('Makers Mark', CURRENT_TIMESTAMP + INTERVAL '1 year'),
+    ('Jim Beam', CURRENT_TIMESTAMP + INTERVAL '1 year'),
+    ('Jack Daniels', CURRENT_TIMESTAMP + INTERVAL '1 year');
 
 -- Users
-INSERT INTO public.users (id, name, email, user_type_id, company_id) VALUES
-    (1, 'Alice Johnson', 'alice.johnson.147@example.invalid', 3, 4),
-    (2, 'Bob Smith', 'bob.smith.938@example.invalid', 3, 3),
-    (3, 'Carol Williams', 'carol.williams.259@example.invalid', 4, 1),
-    (4, 'David Brown', 'david.brown.740@example.invalid', 5, 2),
-    (5, 'Eve Davis', 'eve.davis.572@example.invalid', 3, 1),
-    (6, 'Frank Miller', 'frank.miller.863@example.invalid', 4, 2),
-    (7, 'Grace Wilson', 'grace.wilson.314@example.invalid', 5, 3),
-    (8, 'Hank Moore', 'hank.moore.485@example.invalid', 3, 4),
-    (9, 'Ivy Taylor', 'ivy.taylor.697@example.invalid', 4, 1),
-    (10, 'Jake Anderson', 'jake.anderson.208@example.invalid', 5, 2),
-    (11, 'Laura Thomas', 'laura.thomas.559@example.invalid', 3, 3),
-    (12, 'Mike Jackson', 'mike.jackson.631@example.invalid', 4, 4),
-    (13, 'Nina White', 'nina.white.942@example.invalid', 5, 1),
-    (14, 'Oscar Harris', 'oscar.harris.173@example.invalid', 3, 2),
-    (15, 'Paula Martin', 'paula.martin.384@example.invalid', 4, 3),
-    (16, 'Quincy Lee', 'quincy.lee.795@example.invalid', 5, 4),
-    (17, 'Rachel Perez', 'rachel.perez.516@example.invalid', 3, 1),
-    (18, 'Steve Clark', 'steve.clark.627@example.invalid', 4, 2),
-    (19, 'Tina Lewis', 'tina.lewis.838@example.invalid', 5, 3),
-    (20, 'Umar Walker', 'umar.walker.249@example.invalid', 3, 4),
-    (21, 'Victor Hall', 'victor.hall.460@example.invalid', 4, 1),
-    (22, 'Wendy Young', 'wendy.young.571@example.invalid', 5, 2),
-    (23, 'Xavier King', 'xavier.king.682@example.invalid', 3, 3),
-    (24, 'Yvonne Scott', 'yvonne.scott.793@example.invalid', 4, 4),
-    (125, 'Super Admin', 'admin@example.invalid', 1, 1),
-    (126, 'Shaw', 'shaw@caskr.co', 1, 1);
+INSERT INTO public.users (id, name, email, user_type_id, company_id, is_primary_contact) VALUES
+    (1, 'Alice Johnson', 'alice.johnson.147@example.invalid', 3, 4, true),
+    (2, 'Bob Smith', 'bob.smith.938@example.invalid', 3, 3, true),
+    (3, 'Carol Williams', 'carol.williams.259@example.invalid', 4, 1, true),
+    (4, 'David Brown', 'david.brown.740@example.invalid', 5, 2, true),
+    (5, 'Eve Davis', 'eve.davis.572@example.invalid', 3, 1, false),
+    (6, 'Frank Miller', 'frank.miller.863@example.invalid', 4, 2, false),
+    (7, 'Grace Wilson', 'grace.wilson.314@example.invalid', 5, 3, false),
+    (8, 'Hank Moore', 'hank.moore.485@example.invalid', 3, 4, false),
+    (9, 'Ivy Taylor', 'ivy.taylor.697@example.invalid', 4, 1, false),
+    (10, 'Jake Anderson', 'jake.anderson.208@example.invalid', 5, 2, false),
+    (11, 'Laura Thomas', 'laura.thomas.559@example.invalid', 3, 3, false),
+    (12, 'Mike Jackson', 'mike.jackson.631@example.invalid', 4, 4, false),
+    (13, 'Nina White', 'nina.white.942@example.invalid', 5, 1, false),
+    (14, 'Oscar Harris', 'oscar.harris.173@example.invalid', 3, 2, false),
+    (15, 'Paula Martin', 'paula.martin.384@example.invalid', 4, 3, false),
+    (16, 'Quincy Lee', 'quincy.lee.795@example.invalid', 5, 4, false),
+    (17, 'Rachel Perez', 'rachel.perez.516@example.invalid', 3, 1, false),
+    (18, 'Steve Clark', 'steve.clark.627@example.invalid', 4, 2, false),
+    (19, 'Tina Lewis', 'tina.lewis.838@example.invalid', 5, 3, false),
+    (20, 'Umar Walker', 'umar.walker.249@example.invalid', 3, 4, false),
+    (21, 'Victor Hall', 'victor.hall.460@example.invalid', 4, 1, false),
+    (22, 'Wendy Young', 'wendy.young.571@example.invalid', 5, 2, false),
+    (23, 'Xavier King', 'xavier.king.682@example.invalid', 3, 3, false),
+    (24, 'Yvonne Scott', 'yvonne.scott.793@example.invalid', 4, 4, false),
+    (125, 'Super Admin', 'admin@example.invalid', 1, 1, false),
+    (126, 'Shaw', 'shaw@caskr.co', 1, 1, false);
 
 -- Products
 INSERT INTO public.products (id, owner_id, notes) VALUES


### PR DESCRIPTION
## Summary
- remove the primary contact relationship from the company EF model and schema
- add an is_primary_contact flag to the users EF model and SQL schema
- update seed data to populate the new flag for legacy primary contacts

## Testing
- dotnet restore *(fails: `dotnet` not available in container)*
- dotnet build --no-restore *(fails: `dotnet` not available in container)*
- dotnet test --no-build *(fails: `dotnet` not available in container)*
- npm --prefix caskr.client test *(fails: Chrome not installed for Playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68d17e19202c832bb6ebfa49bd56f1af