### PR TITLE
Enforce authenticated API access across server and client

### DIFF
--- a/Caskr.Server/Controllers/AuthorizedApiControllerBase.cs
+++ b/Caskr.Server/Controllers/AuthorizedApiControllerBase.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Caskr.server.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+public abstract class AuthorizedApiControllerBase : ControllerBase
+{
+}

--- a/Caskr.Server/Controllers/BarrelsController.cs
+++ b/Caskr.Server/Controllers/BarrelsController.cs
@@ -2,15 +2,11 @@ using System.Security.Claims;
 using Caskr.server;
 using Caskr.server.Models;
 using Caskr.server.Services;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Caskr.server.Controllers
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    [Authorize]
-    public class BarrelsController(IBarrelsService barrelsService, IUsersService usersService) : ControllerBase
+    public class BarrelsController(IBarrelsService barrelsService, IUsersService usersService) : AuthorizedApiControllerBase
     {
         [HttpGet("company/{companyId}")]
         public async Task<ActionResult<IEnumerable<Barrel>>> GetBarrelsForCompany(int companyId)

--- a/Caskr.Server/Controllers/LabelsController.cs
+++ b/Caskr.Server/Controllers/LabelsController.cs
@@ -4,9 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Caskr.server.Controllers;
 
-[ApiController]
-[Route("api/[controller]")]
-public class LabelsController(ILabelsService labelsService) : ControllerBase
+public class LabelsController(ILabelsService labelsService) : AuthorizedApiControllerBase
 {
     [HttpPost("ttb-form")]
     public async Task<IActionResult> GenerateTtbForm([FromBody] LabelRequest request)

--- a/Caskr.Server/Controllers/MashBillsController.cs
+++ b/Caskr.Server/Controllers/MashBillsController.cs
@@ -5,9 +5,7 @@ using System.Collections.Generic;
 
 namespace Caskr.server.Controllers
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    public class MashBillsController(CaskrDbContext dbContext) : ControllerBase
+    public class MashBillsController(CaskrDbContext dbContext) : AuthorizedApiControllerBase
     {
         [HttpGet]
         public async Task<ActionResult<IEnumerable<MashBill>>> GetMashBills()

--- a/Caskr.Server/Controllers/OrdersController.cs
+++ b/Caskr.Server/Controllers/OrdersController.cs
@@ -5,9 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Caskr.server.Controllers
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    public class OrdersController(IOrdersService ordersService) : ControllerBase
+    public class OrdersController(IOrdersService ordersService) : AuthorizedApiControllerBase
     {
         // GET: api/Orders
         [HttpGet]

--- a/Caskr.Server/Controllers/ProductsController.cs
+++ b/Caskr.Server/Controllers/ProductsController.cs
@@ -4,9 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Caskr.server.Controllers
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    public class ProductsController(IProductsService productsService) : ControllerBase
+    public class ProductsController(IProductsService productsService) : AuthorizedApiControllerBase
     {
         // GET: api/Products
         [HttpGet]

--- a/Caskr.Server/Controllers/SpiritTypesController.cs
+++ b/Caskr.Server/Controllers/SpiritTypesController.cs
@@ -5,9 +5,7 @@ using System.Collections.Generic;
 
 namespace Caskr.server.Controllers
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    public class SpiritTypesController(CaskrDbContext dbContext) : ControllerBase
+    public class SpiritTypesController(CaskrDbContext dbContext) : AuthorizedApiControllerBase
     {
         [HttpGet]
         public async Task<ActionResult<IEnumerable<SpiritType>>> GetSpiritTypes()

--- a/Caskr.Server/Controllers/StatusController.cs
+++ b/Caskr.Server/Controllers/StatusController.cs
@@ -4,9 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Caskr.server.Controllers
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    public class StatusController(IStatusService statusService) : ControllerBase
+    public class StatusController(IStatusService statusService) : AuthorizedApiControllerBase
     {
         // GET: api/Status
         [HttpGet]

--- a/Caskr.Server/Controllers/TransfersController.cs
+++ b/Caskr.Server/Controllers/TransfersController.cs
@@ -4,9 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Caskr.server.Controllers;
 
-[ApiController]
-[Route("api/[controller]")]
-public class TransfersController(ITransfersService transfersService) : ControllerBase
+public class TransfersController(ITransfersService transfersService) : AuthorizedApiControllerBase
 {
     [HttpPost("ttb-form")]
     public async Task<IActionResult> GenerateTtbForm([FromBody] TransferRequest request)

--- a/Caskr.Server/Controllers/UserTypesController.cs
+++ b/Caskr.Server/Controllers/UserTypesController.cs
@@ -5,9 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Caskr.server.Controllers
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    public class UserTypesController(IUserTypesService userTypesService) : ControllerBase
+    public class UserTypesController(IUserTypesService userTypesService) : AuthorizedApiControllerBase
     {
         // GET: api/UserTypes
         [HttpGet]

--- a/Caskr.Server/Controllers/UsersController.cs
+++ b/Caskr.Server/Controllers/UsersController.cs
@@ -2,15 +2,11 @@ using System.Security.Claims;
 using Caskr.server;
 using Caskr.server.Models;
 using Caskr.server.Services;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Caskr.server.Controllers
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    [Authorize]
-    public class UsersController(IUsersService usersService) : ControllerBase
+    public class UsersController(IUsersService usersService) : AuthorizedApiControllerBase
     {
         // GET: api/Users
         [HttpGet]

--- a/caskr.client/src/api/authorizedFetch.ts
+++ b/caskr.client/src/api/authorizedFetch.ts
@@ -1,0 +1,10 @@
+export const authorizedFetch = async (input: RequestInfo | URL, init: RequestInit = {}) => {
+  const token = localStorage.getItem('token')
+  const headers = new Headers(init.headers ?? {})
+
+  if (token && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${token}`)
+  }
+
+  return fetch(input, { ...init, headers })
+}

--- a/caskr.client/src/components/LabelModal.tsx
+++ b/caskr.client/src/components/LabelModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useAppSelector } from '../hooks'
+import { authorizedFetch } from '../api/authorizedFetch'
 import './CreateOrderModal.css'
 
 type Props = {
@@ -16,7 +17,7 @@ const LabelModal = ({ isOpen, onClose }: Props) => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!user) return
-    const response = await fetch('/api/labels/ttb-form', {
+    const response = await authorizedFetch('/api/labels/ttb-form', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/caskr.client/src/components/TransferModal.tsx
+++ b/caskr.client/src/components/TransferModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useAppSelector } from '../hooks'
+import { authorizedFetch } from '../api/authorizedFetch'
 import './CreateOrderModal.css'
 
 type Props = {
@@ -17,7 +18,7 @@ const TransferModal = ({ isOpen, onClose }: Props) => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!user) return
-    const response = await fetch('/api/transfers/ttb-form', {
+    const response = await authorizedFetch('/api/transfers/ttb-form', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/caskr.client/src/features/barrelsSlice.ts
+++ b/caskr.client/src/features/barrelsSlice.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { authorizedFetch } from '../api/authorizedFetch'
 
 export interface Barrel {
   id: number
@@ -12,7 +13,7 @@ export interface Barrel {
 export const fetchBarrels = createAsyncThunk(
   'barrels/fetchBarrels',
   async (companyId: number) => {
-    const response = await fetch(`api/barrels/company/${companyId}`)
+    const response = await authorizedFetch(`api/barrels/company/${companyId}`)
     if (!response.ok) throw new Error('Failed to fetch barrels')
     return (await response.json()) as Barrel[]
   }
@@ -27,7 +28,7 @@ export interface ForecastParams {
 export const forecastBarrels = createAsyncThunk(
   'barrels/forecast',
   async ({ companyId, targetDate, ageYears }: ForecastParams) => {
-    const response = await fetch(
+    const response = await authorizedFetch(
       `api/barrels/company/${companyId}/forecast?targetDate=${encodeURIComponent(targetDate)}&ageYears=${ageYears}`
     )
     if (!response.ok) throw new Error('Failed to forecast barrels')

--- a/caskr.client/src/features/mashBillsSlice.ts
+++ b/caskr.client/src/features/mashBillsSlice.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { authorizedFetch } from '../api/authorizedFetch'
 
 export interface MashBill {
   id: number
@@ -6,7 +7,7 @@ export interface MashBill {
 }
 
 export const fetchMashBills = createAsyncThunk('mashBills/fetchMashBills', async () => {
-  const response = await fetch('api/mashbills')
+  const response = await authorizedFetch('api/mashbills')
   if (!response.ok) throw new Error('Failed to fetch mash bills')
   return (await response.json()) as MashBill[]
 })

--- a/caskr.client/src/features/ordersSlice.ts
+++ b/caskr.client/src/features/ordersSlice.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { authorizedFetch } from '../api/authorizedFetch'
 import type { StatusTask } from './statusSlice'
 
 export interface Order {
@@ -12,13 +13,13 @@ export interface Order {
 }
 
 export const fetchOrders = createAsyncThunk('orders/fetchOrders', async () => {
-  const response = await fetch('api/orders')
+  const response = await authorizedFetch('api/orders')
   if (!response.ok) throw new Error('Failed to fetch orders')
   return (await response.json()) as Order[]
 })
 
 export const addOrder = createAsyncThunk('orders/addOrder', async (order: Omit<Order, 'id'>) => {
-  const response = await fetch('api/orders', {
+  const response = await authorizedFetch('api/orders', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(order)
@@ -28,7 +29,7 @@ export const addOrder = createAsyncThunk('orders/addOrder', async (order: Omit<O
 })
 
 export const updateOrder = createAsyncThunk('orders/updateOrder', async (order: Order) => {
-  const response = await fetch(`api/orders/${order.id}`, {
+  const response = await authorizedFetch(`api/orders/${order.id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(order)
@@ -38,7 +39,7 @@ export const updateOrder = createAsyncThunk('orders/updateOrder', async (order: 
 })
 
 export const deleteOrder = createAsyncThunk('orders/deleteOrder', async (id: number) => {
-  const response = await fetch(`api/orders/${id}`, { method: 'DELETE' })
+  const response = await authorizedFetch(`api/orders/${id}`, { method: 'DELETE' })
   if (!response.ok) throw new Error('Failed to delete order')
   return id
 })
@@ -46,7 +47,7 @@ export const deleteOrder = createAsyncThunk('orders/deleteOrder', async (id: num
 export const fetchOutstandingTasks = createAsyncThunk(
   'orders/fetchOutstandingTasks',
   async (orderId: number) => {
-    const response = await fetch(`api/orders/${orderId}/outstanding-tasks`)
+    const response = await authorizedFetch(`api/orders/${orderId}/outstanding-tasks`)
     if (!response.ok) throw new Error('Failed to fetch outstanding tasks')
     return { orderId, tasks: (await response.json()) as StatusTask[] }
   }

--- a/caskr.client/src/features/productsSlice.ts
+++ b/caskr.client/src/features/productsSlice.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { authorizedFetch } from '../api/authorizedFetch'
 
 export interface Product {
   id: number
@@ -7,13 +8,13 @@ export interface Product {
 }
 
 export const fetchProducts = createAsyncThunk('products/fetchProducts', async () => {
-  const response = await fetch('api/products')
+  const response = await authorizedFetch('api/products')
   if (!response.ok) throw new Error('Failed to fetch products')
   return (await response.json()) as Product[]
 })
 
 export const addProduct = createAsyncThunk('products/addProduct', async (product: Omit<Product, 'id'>) => {
-  const response = await fetch('api/products', {
+  const response = await authorizedFetch('api/products', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(product)
@@ -23,7 +24,7 @@ export const addProduct = createAsyncThunk('products/addProduct', async (product
 })
 
 export const updateProduct = createAsyncThunk('products/updateProduct', async (product: Product) => {
-  const response = await fetch(`api/products/${product.id}`, {
+  const response = await authorizedFetch(`api/products/${product.id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(product)
@@ -33,7 +34,7 @@ export const updateProduct = createAsyncThunk('products/updateProduct', async (p
 })
 
 export const deleteProduct = createAsyncThunk('products/deleteProduct', async (id: number) => {
-  const response = await fetch(`api/products/${id}`, { method: 'DELETE' })
+  const response = await authorizedFetch(`api/products/${id}`, { method: 'DELETE' })
   if (!response.ok) throw new Error('Failed to delete product')
   return id
 })

--- a/caskr.client/src/features/spiritTypesSlice.ts
+++ b/caskr.client/src/features/spiritTypesSlice.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { authorizedFetch } from '../api/authorizedFetch'
 
 export interface SpiritType {
   id: number
@@ -6,7 +7,7 @@ export interface SpiritType {
 }
 
 export const fetchSpiritTypes = createAsyncThunk('spiritTypes/fetchSpiritTypes', async () => {
-  const response = await fetch('api/spirittypes')
+  const response = await authorizedFetch('api/spirittypes')
   if (!response.ok) throw new Error('Failed to fetch spirit types')
   return (await response.json()) as SpiritType[]
 })

--- a/caskr.client/src/features/statusSlice.ts
+++ b/caskr.client/src/features/statusSlice.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { authorizedFetch } from '../api/authorizedFetch'
 
 export interface StatusTask {
   id: number
@@ -13,13 +14,13 @@ export interface Status {
 }
 
 export const fetchStatuses = createAsyncThunk('statuses/fetchStatuses', async () => {
-  const response = await fetch('api/status')
+  const response = await authorizedFetch('api/status')
   if (!response.ok) throw new Error('Failed to fetch statuses')
   return (await response.json()) as Status[]
 })
 
 export const addStatus = createAsyncThunk('statuses/addStatus', async (status: Omit<Status, 'id' | 'statusTasks'>) => {
-  const response = await fetch('api/status', {
+  const response = await authorizedFetch('api/status', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(status)
@@ -29,7 +30,7 @@ export const addStatus = createAsyncThunk('statuses/addStatus', async (status: O
 })
 
 export const updateStatus = createAsyncThunk('statuses/updateStatus', async (status: Omit<Status, 'statusTasks'>) => {
-  const response = await fetch(`api/status/${status.id}`, {
+  const response = await authorizedFetch(`api/status/${status.id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(status)
@@ -39,7 +40,7 @@ export const updateStatus = createAsyncThunk('statuses/updateStatus', async (sta
 })
 
 export const deleteStatus = createAsyncThunk('statuses/deleteStatus', async (id: number) => {
-  const response = await fetch(`api/status/${id}`, { method: 'DELETE' })
+  const response = await authorizedFetch(`api/status/${id}`, { method: 'DELETE' })
   if (!response.ok) throw new Error('Failed to delete status')
   return id
 })

--- a/caskr.client/src/features/userTypesSlice.ts
+++ b/caskr.client/src/features/userTypesSlice.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { authorizedFetch } from '../api/authorizedFetch'
 
 export interface UserType {
   id: number
@@ -6,13 +7,13 @@ export interface UserType {
 }
 
 export const fetchUserTypes = createAsyncThunk('userTypes/fetchUserTypes', async () => {
-  const response = await fetch('api/usertypes')
+  const response = await authorizedFetch('api/usertypes')
   if (!response.ok) throw new Error('Failed to fetch user types')
   return (await response.json()) as UserType[]
 })
 
 export const addUserType = createAsyncThunk('userTypes/addUserType', async (userType: Omit<UserType, 'id'>) => {
-  const response = await fetch('api/usertypes', {
+  const response = await authorizedFetch('api/usertypes', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(userType)
@@ -22,7 +23,7 @@ export const addUserType = createAsyncThunk('userTypes/addUserType', async (user
 })
 
 export const updateUserType = createAsyncThunk('userTypes/updateUserType', async (userType: UserType) => {
-  const response = await fetch(`api/usertypes/${userType.id}`, {
+  const response = await authorizedFetch(`api/usertypes/${userType.id}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(userType)
@@ -32,7 +33,7 @@ export const updateUserType = createAsyncThunk('userTypes/updateUserType', async
 })
 
 export const deleteUserType = createAsyncThunk('userTypes/deleteUserType', async (id: number) => {
-  const response = await fetch(`api/usertypes/${id}`, { method: 'DELETE' })
+  const response = await authorizedFetch(`api/usertypes/${id}`, { method: 'DELETE' })
   if (!response.ok) throw new Error('Failed to delete user type')
   return id
 })

--- a/caskr.client/src/features/usersSlice.ts
+++ b/caskr.client/src/features/usersSlice.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { authorizedFetch } from '../api/authorizedFetch'
 
 export interface User {
   id: number
@@ -17,21 +18,16 @@ export interface NewUser {
 }
 
 export const fetchUsers = createAsyncThunk('users/fetchUsers', async () => {
-  const token = localStorage.getItem('token')
-  const response = await fetch('api/users', {
-    headers: token ? { 'Authorization': `Bearer ${token}` } : undefined
-  })
+  const response = await authorizedFetch('api/users')
   if (!response.ok) throw new Error('Failed to fetch users')
   return (await response.json()) as User[]
 })
 
 export const addUser = createAsyncThunk('users/addUser', async (user: NewUser) => {
-  const token = localStorage.getItem('token')
-  const response = await fetch('api/users', {
+  const response = await authorizedFetch('api/users', {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
-      ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+      'Content-Type': 'application/json'
     },
     body: JSON.stringify(user)
   })
@@ -40,12 +36,10 @@ export const addUser = createAsyncThunk('users/addUser', async (user: NewUser) =
 })
 
 export const updateUser = createAsyncThunk('users/updateUser', async (user: User) => {
-  const token = localStorage.getItem('token')
-  const response = await fetch(`api/users/${user.id}`, {
+  const response = await authorizedFetch(`api/users/${user.id}`, {
     method: 'PUT',
     headers: {
-      'Content-Type': 'application/json',
-      ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+      'Content-Type': 'application/json'
     },
     body: JSON.stringify(user)
   })
@@ -54,10 +48,8 @@ export const updateUser = createAsyncThunk('users/updateUser', async (user: User
 })
 
 export const deleteUser = createAsyncThunk('users/deleteUser', async (id: number) => {
-  const token = localStorage.getItem('token')
-  const response = await fetch(`api/users/${id}`, {
-    method: 'DELETE',
-    headers: token ? { 'Authorization': `Bearer ${token}` } : undefined
+  const response = await authorizedFetch(`api/users/${id}`, {
+    method: 'DELETE'
   })
   if (!response.ok) throw new Error('Failed to delete user')
   return id

--- a/caskr.client/src/pages/LoginPage.tsx
+++ b/caskr.client/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { authorizedFetch } from '../api/authorizedFetch'
 
 function LoginPage() {
   const [email, setEmail] = useState('')
@@ -9,7 +10,7 @@ function LoginPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    const response = await fetch('api/auth/login', {
+    const response = await authorizedFetch('api/auth/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, password })


### PR DESCRIPTION
## Summary
- add a shared `AuthorizedApiControllerBase` that applies `[Authorize]` to all API controllers
- update server controllers to inherit from the shared base class
- introduce an `authorizedFetch` helper and route client data calls through it so the bearer token is sent automatically

## Testing
- ⚠️ `dotnet restore` *(fails: dotnet command is not available in the environment)*
- ⚠️ `dotnet build --no-restore` *(not run because restore is unavailable)*
- ⚠️ `dotnet test --no-build` *(not run because restore is unavailable)*
- ⚠️ `npm --prefix caskr.client test` *(fails: Chrome browser is not installed for Playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68d186349d6c832b9f86fd129598c855