### PR TITLE
Normalize barrel forecast target dates to UTC

### DIFF
--- a/Caskr.Server.Tests/BarrelsServiceTests.cs
+++ b/Caskr.Server.Tests/BarrelsServiceTests.cs
@@ -1,0 +1,28 @@
+using Caskr.server.Models;
+using Caskr.server.Repos;
+using Caskr.server.Services;
+using Moq;
+
+namespace Caskr.Server.Tests;
+
+public class BarrelsServiceTests
+{
+    [Fact]
+    public async Task ForecastBarrelsAsync_NormalizesUnspecifiedDateToUtc()
+    {
+        var repository = new Mock<IBarrelsRepository>();
+        DateTime capturedTargetDate = default;
+        repository
+            .Setup(r => r.ForecastBarrelsAsync(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<int>()))
+            .Callback<int, DateTime, int>((_, targetDate, _) => capturedTargetDate = targetDate)
+            .ReturnsAsync(Array.Empty<Barrel>());
+
+        var service = new BarrelsService(repository.Object);
+        var unspecifiedTargetDate = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
+
+        await service.ForecastBarrelsAsync(1, unspecifiedTargetDate, 5);
+
+        Assert.Equal(DateTimeKind.Utc, capturedTargetDate.Kind);
+        Assert.Equal(DateTime.SpecifyKind(unspecifiedTargetDate, DateTimeKind.Utc), capturedTargetDate);
+    }
+}

--- a/Caskr.Server/Services/BarrelsService.cs
+++ b/Caskr.Server/Services/BarrelsService.cs
@@ -18,7 +18,18 @@ namespace Caskr.server.Services
 
         public Task<IEnumerable<Barrel>> ForecastBarrelsAsync(int companyId, DateTime targetDate, int ageYears)
         {
-            return repository.ForecastBarrelsAsync(companyId, targetDate, ageYears);
+            var normalizedTargetDate = NormalizeToUtc(targetDate);
+            return repository.ForecastBarrelsAsync(companyId, normalizedTargetDate, ageYears);
+        }
+
+        private static DateTime NormalizeToUtc(DateTime value)
+        {
+            return value.Kind switch
+            {
+                DateTimeKind.Utc => value,
+                DateTimeKind.Local => value.ToUniversalTime(),
+                _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+            };
         }
     }
 }


### PR DESCRIPTION
## Summary
- normalize forecast target dates to UTC before querying for barrels
- add a service unit test to ensure unspecified dates are treated as UTC

## Testing
- dotnet restore *(fails: `dotnet` not available in container)*
- npm --prefix caskr.client test *(fails: Chromium distribution 'chrome' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d18ee689e4832b8a6833d0c148d886