### PR TITLE
Add barrel CSV import flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 All changes must ensure the .NET solution builds and **all tests run and pass**.
 
+Each pull request must include at least one new automated test that exercises the
+behaviour introduced or modified by the change.
+
+Before finishing a task, verify that every project builds successfully and that
+the full test suite completes without failures.
+
 Before committing, run:
 
 ```bash

--- a/Caskr.Server.Tests/BarrelsControllerTests.cs
+++ b/Caskr.Server.Tests/BarrelsControllerTests.cs
@@ -4,6 +4,7 @@ using Caskr.server.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
+using System.IO;
 using System.Security.Claims;
 using UserTypeEnum = Caskr.server.UserType;
 
@@ -56,6 +57,60 @@ public class BarrelsControllerTests
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var barrels = Assert.IsAssignableFrom<IEnumerable<Barrel>>(ok.Value);
         Assert.Single(barrels);
+    }
+
+    [Fact]
+    public async Task ImportBarrels_NoFile_ReturnsBadRequest()
+    {
+        var user = new User { Id = 3, CompanyId = 1, UserTypeId = (int)UserTypeEnum.Admin };
+        var controller = CreateController(user);
+
+        var response = await controller.ImportBarrels(1, new BarrelImportRequest());
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(response.Result);
+        dynamic payload = badRequest.Value!;
+        Assert.Equal("Please select a CSV file to upload.", (string)payload.message);
+    }
+
+    [Fact]
+    public async Task ImportBarrels_ServiceRequestsMashBill_ReturnsBadRequestWithFlag()
+    {
+        var user = new User { Id = 4, CompanyId = 1, UserTypeId = (int)UserTypeEnum.Admin };
+        var controller = CreateController(user);
+        _barrelsService
+            .Setup(s => s.ImportBarrelsAsync(1, user.Id, It.IsAny<IFormFile>(), null, null))
+            .ThrowsAsync(new BatchRequiredException());
+
+        using var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        var file = new FormFile(stream, 0, stream.Length, "file", "data.csv");
+        var request = new BarrelImportRequest { File = file };
+
+        var response = await controller.ImportBarrels(1, request);
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(response.Result);
+        dynamic payload = badRequest.Value!;
+        Assert.True((bool)payload.requiresMashBillId);
+    }
+
+    [Fact]
+    public async Task ImportBarrels_Success_ReturnsOk()
+    {
+        var user = new User { Id = 5, CompanyId = 2, UserTypeId = (int)UserTypeEnum.Admin };
+        var controller = CreateController(user);
+        _barrelsService
+            .Setup(s => s.ImportBarrelsAsync(2, user.Id, It.IsAny<IFormFile>(), 1, null))
+            .ReturnsAsync(new BarrelImportResult(1, 3, false));
+
+        using var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        var file = new FormFile(stream, 0, stream.Length, "file", "data.csv");
+        var request = new BarrelImportRequest { File = file, BatchId = 1 };
+
+        var response = await controller.ImportBarrels(2, request);
+
+        var ok = Assert.IsType<OkObjectResult>(response.Result);
+        dynamic payload = ok.Value!;
+        Assert.Equal(3, (int)payload.created);
+        Assert.Equal(1, (int)payload.batchId);
     }
 }
 

--- a/Caskr.Server.Tests/BarrelsRepositoryTests.cs
+++ b/Caskr.Server.Tests/BarrelsRepositoryTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Caskr.server.Models;
 using Caskr.server.Repos;
 using Microsoft.EntityFrameworkCore;
@@ -54,5 +55,73 @@ public class BarrelsRepositoryTests
         var barrels = result.ToList();
         var single = Assert.Single(barrels);
         Assert.Equal(1, single.Id);
+    }
+
+    [Fact]
+    public async Task CreateBatchAsync_AssignsNextIdPerCompany()
+    {
+        var options = new DbContextOptionsBuilder<CaskrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        using var context = new CaskrDbContext(options);
+        context.MashBills.Add(new MashBill { Id = 1, CompanyId = 1, Name = "MB" });
+        context.Batches.Add(new Batch { Id = 1, CompanyId = 1, MashBillId = 1 });
+        await context.SaveChangesAsync();
+
+        var repo = new BarrelsRepository(context);
+        var newBatchId = await repo.CreateBatchAsync(1, 1);
+
+        Assert.Equal(2, newBatchId);
+        var batch = await context.Batches.SingleAsync(b => b.CompanyId == 1 && b.Id == newBatchId);
+        Assert.Equal(1, batch.MashBillId);
+    }
+
+    [Fact]
+    public async Task EnsureOrderForBatchAsync_CreatesAndUpdatesOrder()
+    {
+        var options = new DbContextOptionsBuilder<CaskrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        using var context = new CaskrDbContext(options);
+        context.Statuses.Add(new Status { Id = 1, Name = "Open" });
+        context.SpiritTypes.Add(new SpiritType { Id = 1, Name = "Whiskey" });
+        context.Batches.Add(new Batch { Id = 1, CompanyId = 1, MashBillId = 1 });
+        await context.SaveChangesAsync();
+
+        var repo = new BarrelsRepository(context);
+        var orderId = await repo.EnsureOrderForBatchAsync(1, 10, 1, 5);
+        var createdOrder = await context.Orders.FindAsync(orderId);
+        Assert.NotNull(createdOrder);
+        Assert.Equal(5, createdOrder!.Quantity);
+
+        var secondCallOrderId = await repo.EnsureOrderForBatchAsync(1, 10, 1, 2);
+        Assert.Equal(orderId, secondCallOrderId);
+        var updatedOrder = await context.Orders.FindAsync(orderId);
+        Assert.Equal(7, updatedOrder!.Quantity);
+    }
+
+    [Fact]
+    public async Task GetRickhouseIdsByNameAsync_ReturnsMatchesIgnoringCase()
+    {
+        var options = new DbContextOptionsBuilder<CaskrDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        using var context = new CaskrDbContext(options);
+        context.Rickhouses.AddRange(
+            new Rickhouse { Id = 1, CompanyId = 1, Name = "Alpha", Address = "A" },
+            new Rickhouse { Id = 2, CompanyId = 1, Name = "Beta", Address = "B" },
+            new Rickhouse { Id = 3, CompanyId = 2, Name = "Gamma", Address = "C" }
+        );
+        await context.SaveChangesAsync();
+
+        var repo = new BarrelsRepository(context);
+        var map = await repo.GetRickhouseIdsByNameAsync(1, new[] { "alpha", "beta", "missing" });
+
+        Assert.Equal(2, map.Count);
+        Assert.Equal(1, map["alpha"]);
+        Assert.Equal(2, map["beta"]);
     }
 }

--- a/Caskr.Server.Tests/BarrelsServiceTests.cs
+++ b/Caskr.Server.Tests/BarrelsServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,6 +8,7 @@ using Caskr.server.Repos;
 using Caskr.server.Services;
 using Microsoft.AspNetCore.Http;
 using Moq;
+using Xunit;
 
 namespace Caskr.Server.Tests;
 

--- a/Caskr.Server.Tests/BarrelsServiceTests.cs
+++ b/Caskr.Server.Tests/BarrelsServiceTests.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Caskr.server.Models;
+using Caskr.server.Repos;
+using Caskr.server.Services;
+using Microsoft.AspNetCore.Http;
+using Moq;
+
+namespace Caskr.Server.Tests;
+
+public class BarrelsServiceTests
+{
+    private readonly Mock<IBarrelsRepository> _repository = new();
+    private readonly BarrelsService _service;
+
+    public BarrelsServiceTests()
+    {
+        _service = new BarrelsService(_repository.Object);
+    }
+
+    [Fact]
+    public async Task ImportBarrelsAsync_NoBatchOrMashBill_Throws()
+    {
+        var file = CreateCsvFile("sku,rickhouse\nSKU1,R1");
+
+        await Assert.ThrowsAsync<BatchRequiredException>(() =>
+            _service.ImportBarrelsAsync(1, 2, file, null, null));
+    }
+
+    [Fact]
+    public async Task ImportBarrelsAsync_WithMashBill_CreatesBatchAndBarrels()
+    {
+        var file = CreateCsvFile("sku,rickhouse\nSKU1,R1\nSKU2,R1");
+
+        _repository.Setup(r => r.GetRickhouseIdsByNameAsync(1, It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(new Dictionary<string, int> { { "r1", 10 } });
+        _repository.Setup(r => r.MashBillExistsForCompanyAsync(1, 5)).ReturnsAsync(true);
+        _repository.Setup(r => r.CreateBatchAsync(1, 5)).ReturnsAsync(3);
+        _repository.Setup(r => r.EnsureOrderForBatchAsync(1, 2, 3, 2)).ReturnsAsync(7);
+
+        IEnumerable<Barrel>? savedBarrels = null;
+        _repository
+            .Setup(r => r.AddBarrelsAsync(It.IsAny<IEnumerable<Barrel>>()))
+            .Callback<IEnumerable<Barrel>>(barrels => savedBarrels = barrels)
+            .Returns(Task.CompletedTask);
+
+        var result = await _service.ImportBarrelsAsync(1, 2, file, null, 5);
+
+        Assert.Equal(3, result.BatchId);
+        Assert.Equal(2, result.CreatedCount);
+        Assert.True(result.CreatedNewBatch);
+
+        Assert.NotNull(savedBarrels);
+        var list = savedBarrels!.ToList();
+        Assert.All(list, barrel =>
+        {
+            Assert.Equal(1, barrel.CompanyId);
+            Assert.Equal(3, barrel.BatchId);
+            Assert.Equal(7, barrel.OrderId);
+            Assert.Equal(10, barrel.RickhouseId);
+        });
+        Assert.Contains(list, barrel => barrel.Sku == "SKU1");
+        Assert.Contains(list, barrel => barrel.Sku == "SKU2");
+    }
+
+    [Fact]
+    public async Task ImportBarrelsAsync_WithExistingBatch_DoesNotCreateNewBatch()
+    {
+        var file = CreateCsvFile("SKU1,R1");
+
+        _repository.Setup(r => r.GetRickhouseIdsByNameAsync(1, It.IsAny<IEnumerable<string>>()))
+            .ReturnsAsync(new Dictionary<string, int> { { "r1", 10 } });
+        _repository.Setup(r => r.BatchExistsForCompanyAsync(1, 4)).ReturnsAsync(true);
+        _repository.Setup(r => r.EnsureOrderForBatchAsync(1, 2, 4, 1)).ReturnsAsync(9);
+        _repository.Setup(r => r.AddBarrelsAsync(It.IsAny<IEnumerable<Barrel>>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _service.ImportBarrelsAsync(1, 2, file, 4, null);
+
+        Assert.Equal(4, result.BatchId);
+        Assert.False(result.CreatedNewBatch);
+        _repository.Verify(r => r.CreateBatchAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    private static IFormFile CreateCsvFile(string content)
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+        var stream = new MemoryStream(bytes);
+        return new FormFile(stream, 0, bytes.Length, "file", "barrels.csv");
+    }
+}

--- a/Caskr.Server/Controllers/BarrelsController.cs
+++ b/Caskr.Server/Controllers/BarrelsController.cs
@@ -2,48 +2,91 @@ using System.Security.Claims;
 using Caskr.server;
 using Caskr.server.Models;
 using Caskr.server.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Caskr.server.Controllers
+namespace Caskr.server.Controllers;
+
+public class BarrelImportRequest
 {
-    public class BarrelsController(IBarrelsService barrelsService, IUsersService usersService) : AuthorizedApiControllerBase
+    public IFormFile? File { get; set; }
+
+    public int? BatchId { get; set; }
+
+    public int? MashBillId { get; set; }
+}
+public class BarrelsController(IBarrelsService barrelsService, IUsersService usersService) : AuthorizedApiControllerBase
+{
+    [HttpGet("company/{companyId}")]
+    public async Task<ActionResult<IEnumerable<Barrel>>> GetBarrelsForCompany(int companyId)
     {
-        [HttpGet("company/{companyId}")]
-        public async Task<ActionResult<IEnumerable<Barrel>>> GetBarrelsForCompany(int companyId)
+        var user = await GetCurrentUserAsync();
+        if (user is null || ((UserType)user.UserTypeId != UserType.SuperAdmin && user.CompanyId != companyId))
         {
-            var user = await GetCurrentUserAsync();
-            if (user is null || ((UserType)user.UserTypeId != UserType.SuperAdmin && user.CompanyId != companyId))
-            {
-                return Forbid();
-            }
-
-            var barrels = await barrelsService.GetBarrelsForCompanyAsync(companyId);
-            return Ok(barrels.ToList());
+            return Forbid();
         }
 
-        [HttpGet("company/{companyId}/forecast")]
-        public async Task<ActionResult<object>> Forecast(int companyId, [FromQuery] DateTime targetDate, [FromQuery] int ageYears)
-        {
-            var user = await GetCurrentUserAsync();
-            if (user is null || ((UserType)user.UserTypeId != UserType.SuperAdmin && user.CompanyId != companyId))
-            {
-                return Forbid();
-            }
+        var barrels = await barrelsService.GetBarrelsForCompanyAsync(companyId);
+        return Ok(barrels.ToList());
+    }
 
-            var barrels = await barrelsService.ForecastBarrelsAsync(companyId, targetDate, ageYears);
-            var list = barrels.ToList();
-            return Ok(new { barrels = list, count = list.Count });
+    [HttpGet("company/{companyId}/forecast")]
+    public async Task<ActionResult<object>> Forecast(int companyId, [FromQuery] DateTime targetDate, [FromQuery] int ageYears)
+    {
+        var user = await GetCurrentUserAsync();
+        if (user is null || ((UserType)user.UserTypeId != UserType.SuperAdmin && user.CompanyId != companyId))
+        {
+            return Forbid();
         }
 
-        private async Task<User?> GetCurrentUserAsync()
-        {
-            var userIdValue = User.FindFirstValue(ClaimTypes.NameIdentifier);
-            if (!int.TryParse(userIdValue, out var userId))
-            {
-                return null;
-            }
+        var barrels = await barrelsService.ForecastBarrelsAsync(companyId, targetDate, ageYears);
+        var list = barrels.ToList();
+        return Ok(new { barrels = list, count = list.Count });
+    }
 
-            return await usersService.GetUserByIdAsync(userId);
+    [HttpPost("company/{companyId}/import")]
+    [RequestSizeLimit(10 * 1024 * 1024)]
+    public async Task<ActionResult<object>> ImportBarrels(int companyId, [FromForm] BarrelImportRequest request)
+    {
+        var user = await GetCurrentUserAsync();
+        if (user is null || ((UserType)user.UserTypeId != UserType.SuperAdmin && user.CompanyId != companyId))
+        {
+            return Forbid();
         }
+
+        if (request.File is null || request.File.Length == 0)
+        {
+            return BadRequest(new { message = "Please select a CSV file to upload." });
+        }
+
+        try
+        {
+            var result = await barrelsService.ImportBarrelsAsync(companyId, user.Id, request.File, request.BatchId, request.MashBillId);
+            return Ok(new
+            {
+                created = result.CreatedCount,
+                batchId = result.BatchId,
+                createdNewBatch = result.CreatedNewBatch
+            });
+        }
+        catch (BatchRequiredException ex)
+        {
+            return BadRequest(new { message = ex.Message, requiresMashBillId = true });
+        }
+        catch (BarrelImportException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    private async Task<User?> GetCurrentUserAsync()
+    {
+        var userIdValue = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!int.TryParse(userIdValue, out var userId))
+        {
+            return null;
+        }
+
+        return await usersService.GetUserByIdAsync(userId);
     }
 }

--- a/Caskr.Server/Repos/BarrelsRepository.cs
+++ b/Caskr.Server/Repos/BarrelsRepository.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Caskr.server.Models;
 using Microsoft.EntityFrameworkCore;
 
@@ -7,6 +10,12 @@ namespace Caskr.server.Repos
     {
         Task<IEnumerable<Barrel>> GetBarrelsForCompanyAsync(int companyId);
         Task<IEnumerable<Barrel>> ForecastBarrelsAsync(int companyId, DateTime targetDate, int ageYears);
+        Task<Dictionary<string, int>> GetRickhouseIdsByNameAsync(int companyId, IEnumerable<string> normalizedNames);
+        Task<bool> BatchExistsForCompanyAsync(int companyId, int batchId);
+        Task<bool> MashBillExistsForCompanyAsync(int companyId, int mashBillId);
+        Task<int> CreateBatchAsync(int companyId, int mashBillId);
+        Task<int> EnsureOrderForBatchAsync(int companyId, int ownerId, int batchId, int quantity);
+        Task AddBarrelsAsync(IEnumerable<Barrel> barrels);
     }
 
     public class BarrelsRepository(CaskrDbContext dbContext) : IBarrelsRepository
@@ -26,6 +35,98 @@ namespace Caskr.server.Repos
                 .Include(b => b.Order)
                 .Where(b => b.CompanyId == companyId && b.Order != null && b.Order.CreatedAt <= cutoffDate)
                 .ToListAsync();
+        }
+
+        public async Task<Dictionary<string, int>> GetRickhouseIdsByNameAsync(int companyId, IEnumerable<string> normalizedNames)
+        {
+            var normalizedSet = normalizedNames.Select(n => n.ToLowerInvariant()).ToHashSet();
+            return await dbContext.Rickhouses
+                .Where(r => r.CompanyId == companyId && normalizedSet.Contains(r.Name.ToLowerInvariant()))
+                .ToDictionaryAsync(r => r.Name.ToLowerInvariant(), r => r.Id);
+        }
+
+        public Task<bool> BatchExistsForCompanyAsync(int companyId, int batchId)
+        {
+            return dbContext.Batches.AnyAsync(b => b.CompanyId == companyId && b.Id == batchId);
+        }
+
+        public Task<bool> MashBillExistsForCompanyAsync(int companyId, int mashBillId)
+        {
+            return dbContext.MashBills.AnyAsync(m => m.CompanyId == companyId && m.Id == mashBillId);
+        }
+
+        public async Task<int> CreateBatchAsync(int companyId, int mashBillId)
+        {
+            var nextId = await dbContext.Batches
+                .Where(b => b.CompanyId == companyId)
+                .Select(b => b.Id)
+                .DefaultIfEmpty(0)
+                .MaxAsync() + 1;
+
+            var batch = new Batch
+            {
+                Id = nextId,
+                CompanyId = companyId,
+                MashBillId = mashBillId
+            };
+
+            dbContext.Batches.Add(batch);
+            await dbContext.SaveChangesAsync();
+            return batch.Id;
+        }
+
+        public async Task<int> EnsureOrderForBatchAsync(int companyId, int ownerId, int batchId, int quantity)
+        {
+            var order = await dbContext.Orders
+                .Where(o => o.CompanyId == companyId && o.BatchId == batchId)
+                .OrderBy(o => o.Id)
+                .FirstOrDefaultAsync();
+
+            if (order is not null)
+            {
+                order.Quantity += quantity;
+                order.UpdatedAt = DateTime.UtcNow;
+                await dbContext.SaveChangesAsync();
+                return order.Id;
+            }
+
+            var statusId = await dbContext.Statuses
+                .OrderBy(s => s.Id)
+                .Select(s => s.Id)
+                .FirstOrDefaultAsync();
+
+            var spiritTypeId = await dbContext.SpiritTypes
+                .OrderBy(s => s.Id)
+                .Select(s => s.Id)
+                .FirstOrDefaultAsync();
+
+            if (statusId == 0 || spiritTypeId == 0)
+            {
+                throw new InvalidOperationException("No status or spirit type records are available to create an order.");
+            }
+
+            var newOrder = new Order
+            {
+                Name = $"Imported Barrels {DateTime.UtcNow:yyyyMMddHHmmss}",
+                OwnerId = ownerId,
+                CompanyId = companyId,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                StatusId = statusId,
+                SpiritTypeId = spiritTypeId,
+                BatchId = batchId,
+                Quantity = quantity
+            };
+
+            dbContext.Orders.Add(newOrder);
+            await dbContext.SaveChangesAsync();
+            return newOrder.Id;
+        }
+
+        public async Task AddBarrelsAsync(IEnumerable<Barrel> barrels)
+        {
+            await dbContext.Barrels.AddRangeAsync(barrels);
+            await dbContext.SaveChangesAsync();
         }
     }
 }

--- a/Caskr.Server/Services/BarrelsService.cs
+++ b/Caskr.Server/Services/BarrelsService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/Caskr.Server/Services/BarrelsService.cs
+++ b/Caskr.Server/Services/BarrelsService.cs
@@ -1,196 +1,202 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Caskr.server.Models;
 using Caskr.server.Repos;
 using Microsoft.AspNetCore.Http;
 
-namespace Caskr.server.Services;
-
-public class BarrelImportException : Exception
+namespace Caskr.server.Services
 {
-    public BarrelImportException(string message) : base(message)
+    public class BarrelImportException : Exception
     {
-    }
-}
-
-public class BatchRequiredException : BarrelImportException
-{
-    public BatchRequiredException() : base("A batch ID is required to import barrels.")
-    {
-    }
-}
-
-public class RickhouseNotFoundException : BarrelImportException
-{
-    public RickhouseNotFoundException(IEnumerable<string> names)
-        : base($"Unable to find rickhouses: {string.Join(", ", names)}")
-    {
-    }
-}
-
-public class BatchNotFoundException : BarrelImportException
-{
-    public BatchNotFoundException(int batchId)
-        : base($"Batch {batchId} does not exist for this company.")
-    {
-    }
-}
-
-public class MashBillNotFoundException : BarrelImportException
-{
-    public MashBillNotFoundException(int mashBillId)
-        : base($"Mash bill {mashBillId} does not exist for this company.")
-    {
-    }
-}
-
-public record BarrelImportResult(int BatchId, int CreatedCount, bool CreatedNewBatch);
-
-internal sealed record BarrelImportRow(string Sku, string RickhouseName, string RickhouseKey);
-
-public interface IBarrelsService
-{
-    Task<IEnumerable<Barrel>> GetBarrelsForCompanyAsync(int companyId);
-    Task<IEnumerable<Barrel>> ForecastBarrelsAsync(int companyId, DateTime targetDate, int ageYears);
-    Task<BarrelImportResult> ImportBarrelsAsync(int companyId, int userId, IFormFile file, int? batchId, int? mashBillId);
-}
-
-public class BarrelsService : IBarrelsService
-{
-    private readonly IBarrelsRepository repository;
-
-    public BarrelsService(IBarrelsRepository repository)
-    {
-        this.repository = repository;
-    }
-
-    public Task<IEnumerable<Barrel>> GetBarrelsForCompanyAsync(int companyId)
-    {
-        return repository.GetBarrelsForCompanyAsync(companyId);
-    }
-
-    public Task<IEnumerable<Barrel>> ForecastBarrelsAsync(int companyId, DateTime targetDate, int ageYears)
-    {
-        return repository.ForecastBarrelsAsync(companyId, targetDate, ageYears);
-    }
-
-    public async Task<BarrelImportResult> ImportBarrelsAsync(int companyId, int userId, IFormFile file, int? batchId, int? mashBillId)
-    {
-        if (file is null || file.Length == 0)
+        public BarrelImportException(string message) : base(message)
         {
-            throw new BarrelImportException("A CSV file is required.");
+        }
+    }
+
+    public class BatchRequiredException : BarrelImportException
+    {
+        public BatchRequiredException() : base("A batch ID is required to import barrels.")
+        {
+        }
+    }
+
+    public class RickhouseNotFoundException : BarrelImportException
+    {
+        public RickhouseNotFoundException(IEnumerable<string> names)
+            : base($"Unable to find rickhouses: {string.Join(", ", names)}")
+        {
+        }
+    }
+
+    public class BatchNotFoundException : BarrelImportException
+    {
+        public BatchNotFoundException(int batchId)
+            : base($"Batch {batchId} does not exist for this company.")
+        {
+        }
+    }
+
+    public class MashBillNotFoundException : BarrelImportException
+    {
+        public MashBillNotFoundException(int mashBillId)
+            : base($"Mash bill {mashBillId} does not exist for this company.")
+        {
+        }
+    }
+
+    public record BarrelImportResult(int BatchId, int CreatedCount, bool CreatedNewBatch);
+
+    internal sealed record BarrelImportRow(string Sku, string RickhouseName, string RickhouseKey);
+
+    public interface IBarrelsService
+    {
+        Task<IEnumerable<Barrel>> GetBarrelsForCompanyAsync(int companyId);
+        Task<IEnumerable<Barrel>> ForecastBarrelsAsync(int companyId, DateTime targetDate, int ageYears);
+        Task<BarrelImportResult> ImportBarrelsAsync(int companyId, int userId, IFormFile file, int? batchId, int? mashBillId);
+    }
+
+    public class BarrelsService(IBarrelsRepository repository) : IBarrelsService
+    {
+        public Task<IEnumerable<Barrel>> GetBarrelsForCompanyAsync(int companyId)
+        {
+            return repository.GetBarrelsForCompanyAsync(companyId);
         }
 
-        var rows = await ParseCsvAsync(file);
-        if (rows.Count == 0)
+        public Task<IEnumerable<Barrel>> ForecastBarrelsAsync(int companyId, DateTime targetDate, int ageYears)
         {
-            throw new BarrelImportException("The CSV file did not contain any barrel rows.");
+            var normalizedTargetDate = NormalizeToUtc(targetDate);
+            return repository.ForecastBarrelsAsync(companyId, normalizedTargetDate, ageYears);
         }
 
-        var rickhouseKeys = rows.Select(r => r.RickhouseKey).Distinct().ToList();
-        var rickhouseIds = await repository.GetRickhouseIdsByNameAsync(companyId, rickhouseKeys);
-        var missingRickhouses = rickhouseKeys.Where(key => !rickhouseIds.ContainsKey(key)).ToList();
-        if (missingRickhouses.Count > 0)
+        public async Task<BarrelImportResult> ImportBarrelsAsync(int companyId, int userId, IFormFile file, int? batchId, int? mashBillId)
         {
-            throw new RickhouseNotFoundException(rows
-                .Where(r => missingRickhouses.Contains(r.RickhouseKey))
-                .Select(r => r.RickhouseName)
-                .Distinct());
+            if (file is null || file.Length == 0)
+            {
+                throw new BarrelImportException("A CSV file is required.");
+            }
+
+            var rows = await ParseCsvAsync(file);
+            if (rows.Count == 0)
+            {
+                throw new BarrelImportException("The CSV file did not contain any barrel rows.");
+            }
+
+            var rickhouseKeys = rows.Select(r => r.RickhouseKey).Distinct().ToList();
+            var rickhouseIds = await repository.GetRickhouseIdsByNameAsync(companyId, rickhouseKeys);
+            var missingRickhouses = rickhouseKeys.Where(key => !rickhouseIds.ContainsKey(key)).ToList();
+            if (missingRickhouses.Count > 0)
+            {
+                throw new RickhouseNotFoundException(rows
+                    .Where(r => missingRickhouses.Contains(r.RickhouseKey))
+                    .Select(r => r.RickhouseName)
+                    .Distinct());
+            }
+
+            var resolvedBatchId = batchId;
+            var createdNewBatch = false;
+
+            if (resolvedBatchId.HasValue)
+            {
+                var exists = await repository.BatchExistsForCompanyAsync(companyId, resolvedBatchId.Value);
+                if (!exists)
+                {
+                    throw new BatchNotFoundException(resolvedBatchId.Value);
+                }
+            }
+            else
+            {
+                if (!mashBillId.HasValue)
+                {
+                    throw new BatchRequiredException();
+                }
+
+                var mashBillExists = await repository.MashBillExistsForCompanyAsync(companyId, mashBillId.Value);
+                if (!mashBillExists)
+                {
+                    throw new MashBillNotFoundException(mashBillId.Value);
+                }
+
+                resolvedBatchId = await repository.CreateBatchAsync(companyId, mashBillId.Value);
+                createdNewBatch = true;
+            }
+
+            var orderId = await repository.EnsureOrderForBatchAsync(companyId, userId, resolvedBatchId!.Value, rows.Count);
+
+            var barrels = rows.Select(row => new Barrel
+            {
+                CompanyId = companyId,
+                Sku = row.Sku,
+                BatchId = resolvedBatchId.Value,
+                OrderId = orderId,
+                RickhouseId = rickhouseIds[row.RickhouseKey]
+            });
+
+            await repository.AddBarrelsAsync(barrels);
+
+            return new BarrelImportResult(resolvedBatchId.Value, rows.Count, createdNewBatch);
         }
 
-        var resolvedBatchId = batchId;
-        var createdNewBatch = false;
-
-        if (resolvedBatchId.HasValue)
+        private static async Task<List<BarrelImportRow>> ParseCsvAsync(IFormFile file)
         {
-            var exists = await repository.BatchExistsForCompanyAsync(companyId, resolvedBatchId.Value);
-            if (!exists)
+            using var stream = file.OpenReadStream();
+            using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: false);
+            var rows = new List<BarrelImportRow>();
+            var isFirstRow = true;
+
+            string? line;
+            while ((line = await reader.ReadLineAsync()) != null)
             {
-                throw new BatchNotFoundException(resolvedBatchId.Value);
-            }
-        }
-        else
-        {
-            if (!mashBillId.HasValue)
-            {
-                throw new BatchRequiredException();
-            }
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
 
-            var mashBillExists = await repository.MashBillExistsForCompanyAsync(companyId, mashBillId.Value);
-            if (!mashBillExists)
-            {
-                throw new MashBillNotFoundException(mashBillId.Value);
-            }
+                var parts = line.Split(',', StringSplitOptions.None);
+                if (parts.Length < 2)
+                {
+                    throw new BarrelImportException("Each row must contain a SKU and rickhouse name.");
+                }
 
-            resolvedBatchId = await repository.CreateBatchAsync(companyId, mashBillId.Value);
-            createdNewBatch = true;
-        }
+                var skuValue = parts[0].Trim();
+                var rickhouseValue = parts[1].Trim();
 
-        var orderId = await repository.EnsureOrderForBatchAsync(companyId, userId, resolvedBatchId!.Value, rows.Count);
+                if (isFirstRow && skuValue.Equals("sku", StringComparison.OrdinalIgnoreCase))
+                {
+                    isFirstRow = false;
+                    continue;
+                }
 
-        var barrels = rows.Select(row => new Barrel
-        {
-            CompanyId = companyId,
-            Sku = row.Sku,
-            BatchId = resolvedBatchId.Value,
-            OrderId = orderId,
-            RickhouseId = rickhouseIds[row.RickhouseKey]
-        });
-
-        await repository.AddBarrelsAsync(barrels);
-
-        return new BarrelImportResult(resolvedBatchId.Value, rows.Count, createdNewBatch);
-    }
-
-    private static async Task<List<BarrelImportRow>> ParseCsvAsync(IFormFile file)
-    {
-        using var stream = file.OpenReadStream();
-        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: false);
-        var rows = new List<BarrelImportRow>();
-        var isFirstRow = true;
-
-        string? line;
-        while ((line = await reader.ReadLineAsync()) != null)
-        {
-            if (string.IsNullOrWhiteSpace(line))
-            {
-                continue;
-            }
-
-            var parts = line.Split(',', StringSplitOptions.None);
-            if (parts.Length < 2)
-            {
-                throw new BarrelImportException("Each row must contain a SKU and rickhouse name.");
-            }
-
-            var skuValue = parts[0].Trim();
-            var rickhouseValue = parts[1].Trim();
-
-            if (isFirstRow && skuValue.Equals("sku", StringComparison.OrdinalIgnoreCase))
-            {
                 isFirstRow = false;
-                continue;
+
+                if (string.IsNullOrWhiteSpace(skuValue))
+                {
+                    throw new BarrelImportException("Each row must include a SKU value.");
+                }
+
+                if (string.IsNullOrWhiteSpace(rickhouseValue))
+                {
+                    throw new BarrelImportException("Each row must include a rickhouse name.");
+                }
+
+                var key = NormalizeRickhouseName(rickhouseValue);
+                rows.Add(new BarrelImportRow(skuValue, rickhouseValue, key));
             }
 
-            isFirstRow = false;
-
-            if (string.IsNullOrWhiteSpace(skuValue))
-            {
-                throw new BarrelImportException("Each row must include a SKU value.");
-            }
-
-            if (string.IsNullOrWhiteSpace(rickhouseValue))
-            {
-                throw new BarrelImportException("Each row must include a rickhouse name.");
-            }
-
-            var key = NormalizeRickhouseName(rickhouseValue);
-            rows.Add(new BarrelImportRow(skuValue, rickhouseValue, key));
+            return rows;
         }
 
-        return rows;
-    }
+        private static string NormalizeRickhouseName(string name) => name.Trim().ToLowerInvariant();
 
-    private static string NormalizeRickhouseName(string name) => name.Trim().ToLowerInvariant();
+        private static DateTime NormalizeToUtc(DateTime value)
+        {
+            return value.Kind switch
+            {
+                DateTimeKind.Utc => value,
+                DateTimeKind.Local => value.ToUniversalTime(),
+                _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+            };
+        }
+    }
 }

--- a/Caskr.Server/Services/BarrelsService.cs
+++ b/Caskr.Server/Services/BarrelsService.cs
@@ -1,24 +1,196 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using Caskr.server.Models;
 using Caskr.server.Repos;
+using Microsoft.AspNetCore.Http;
 
-namespace Caskr.server.Services
+namespace Caskr.server.Services;
+
+public class BarrelImportException : Exception
 {
-    public interface IBarrelsService
+    public BarrelImportException(string message) : base(message)
     {
-        Task<IEnumerable<Barrel>> GetBarrelsForCompanyAsync(int companyId);
-        Task<IEnumerable<Barrel>> ForecastBarrelsAsync(int companyId, DateTime targetDate, int ageYears);
+    }
+}
+
+public class BatchRequiredException : BarrelImportException
+{
+    public BatchRequiredException() : base("A batch ID is required to import barrels.")
+    {
+    }
+}
+
+public class RickhouseNotFoundException : BarrelImportException
+{
+    public RickhouseNotFoundException(IEnumerable<string> names)
+        : base($"Unable to find rickhouses: {string.Join(", ", names)}")
+    {
+    }
+}
+
+public class BatchNotFoundException : BarrelImportException
+{
+    public BatchNotFoundException(int batchId)
+        : base($"Batch {batchId} does not exist for this company.")
+    {
+    }
+}
+
+public class MashBillNotFoundException : BarrelImportException
+{
+    public MashBillNotFoundException(int mashBillId)
+        : base($"Mash bill {mashBillId} does not exist for this company.")
+    {
+    }
+}
+
+public record BarrelImportResult(int BatchId, int CreatedCount, bool CreatedNewBatch);
+
+internal sealed record BarrelImportRow(string Sku, string RickhouseName, string RickhouseKey);
+
+public interface IBarrelsService
+{
+    Task<IEnumerable<Barrel>> GetBarrelsForCompanyAsync(int companyId);
+    Task<IEnumerable<Barrel>> ForecastBarrelsAsync(int companyId, DateTime targetDate, int ageYears);
+    Task<BarrelImportResult> ImportBarrelsAsync(int companyId, int userId, IFormFile file, int? batchId, int? mashBillId);
+}
+
+public class BarrelsService : IBarrelsService
+{
+    private readonly IBarrelsRepository repository;
+
+    public BarrelsService(IBarrelsRepository repository)
+    {
+        this.repository = repository;
     }
 
-    public class BarrelsService(IBarrelsRepository repository) : IBarrelsService
+    public Task<IEnumerable<Barrel>> GetBarrelsForCompanyAsync(int companyId)
     {
-        public Task<IEnumerable<Barrel>> GetBarrelsForCompanyAsync(int companyId)
+        return repository.GetBarrelsForCompanyAsync(companyId);
+    }
+
+    public Task<IEnumerable<Barrel>> ForecastBarrelsAsync(int companyId, DateTime targetDate, int ageYears)
+    {
+        return repository.ForecastBarrelsAsync(companyId, targetDate, ageYears);
+    }
+
+    public async Task<BarrelImportResult> ImportBarrelsAsync(int companyId, int userId, IFormFile file, int? batchId, int? mashBillId)
+    {
+        if (file is null || file.Length == 0)
         {
-            return repository.GetBarrelsForCompanyAsync(companyId);
+            throw new BarrelImportException("A CSV file is required.");
         }
 
-        public Task<IEnumerable<Barrel>> ForecastBarrelsAsync(int companyId, DateTime targetDate, int ageYears)
+        var rows = await ParseCsvAsync(file);
+        if (rows.Count == 0)
         {
-            return repository.ForecastBarrelsAsync(companyId, targetDate, ageYears);
+            throw new BarrelImportException("The CSV file did not contain any barrel rows.");
         }
+
+        var rickhouseKeys = rows.Select(r => r.RickhouseKey).Distinct().ToList();
+        var rickhouseIds = await repository.GetRickhouseIdsByNameAsync(companyId, rickhouseKeys);
+        var missingRickhouses = rickhouseKeys.Where(key => !rickhouseIds.ContainsKey(key)).ToList();
+        if (missingRickhouses.Count > 0)
+        {
+            throw new RickhouseNotFoundException(rows
+                .Where(r => missingRickhouses.Contains(r.RickhouseKey))
+                .Select(r => r.RickhouseName)
+                .Distinct());
+        }
+
+        var resolvedBatchId = batchId;
+        var createdNewBatch = false;
+
+        if (resolvedBatchId.HasValue)
+        {
+            var exists = await repository.BatchExistsForCompanyAsync(companyId, resolvedBatchId.Value);
+            if (!exists)
+            {
+                throw new BatchNotFoundException(resolvedBatchId.Value);
+            }
+        }
+        else
+        {
+            if (!mashBillId.HasValue)
+            {
+                throw new BatchRequiredException();
+            }
+
+            var mashBillExists = await repository.MashBillExistsForCompanyAsync(companyId, mashBillId.Value);
+            if (!mashBillExists)
+            {
+                throw new MashBillNotFoundException(mashBillId.Value);
+            }
+
+            resolvedBatchId = await repository.CreateBatchAsync(companyId, mashBillId.Value);
+            createdNewBatch = true;
+        }
+
+        var orderId = await repository.EnsureOrderForBatchAsync(companyId, userId, resolvedBatchId!.Value, rows.Count);
+
+        var barrels = rows.Select(row => new Barrel
+        {
+            CompanyId = companyId,
+            Sku = row.Sku,
+            BatchId = resolvedBatchId.Value,
+            OrderId = orderId,
+            RickhouseId = rickhouseIds[row.RickhouseKey]
+        });
+
+        await repository.AddBarrelsAsync(barrels);
+
+        return new BarrelImportResult(resolvedBatchId.Value, rows.Count, createdNewBatch);
     }
+
+    private static async Task<List<BarrelImportRow>> ParseCsvAsync(IFormFile file)
+    {
+        using var stream = file.OpenReadStream();
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: false);
+        var rows = new List<BarrelImportRow>();
+        var isFirstRow = true;
+
+        string? line;
+        while ((line = await reader.ReadLineAsync()) != null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var parts = line.Split(',', StringSplitOptions.None);
+            if (parts.Length < 2)
+            {
+                throw new BarrelImportException("Each row must contain a SKU and rickhouse name.");
+            }
+
+            var skuValue = parts[0].Trim();
+            var rickhouseValue = parts[1].Trim();
+
+            if (isFirstRow && skuValue.Equals("sku", StringComparison.OrdinalIgnoreCase))
+            {
+                isFirstRow = false;
+                continue;
+            }
+
+            isFirstRow = false;
+
+            if (string.IsNullOrWhiteSpace(skuValue))
+            {
+                throw new BarrelImportException("Each row must include a SKU value.");
+            }
+
+            if (string.IsNullOrWhiteSpace(rickhouseValue))
+            {
+                throw new BarrelImportException("Each row must include a rickhouse name.");
+            }
+
+            var key = NormalizeRickhouseName(rickhouseValue);
+            rows.Add(new BarrelImportRow(skuValue, rickhouseValue, key));
+        }
+
+        return rows;
+    }
+
+    private static string NormalizeRickhouseName(string name) => name.Trim().ToLowerInvariant();
 }

--- a/caskr.client/src/components/BarrelImportModal.tsx
+++ b/caskr.client/src/components/BarrelImportModal.tsx
@@ -1,0 +1,101 @@
+import { FormEvent, useEffect, useState } from 'react'
+
+interface BarrelImportModalProps {
+  isOpen: boolean
+  requireMashBillId: boolean
+  error: string | null
+  onClose: () => void
+  onSubmit: (payload: { file: File; batchId?: number; mashBillId?: number }) => Promise<void>
+}
+
+export default function BarrelImportModal({ isOpen, requireMashBillId, error, onClose, onSubmit }: BarrelImportModalProps) {
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [batchId, setBatchId] = useState('')
+  const [mashBillId, setMashBillId] = useState('')
+  const [localError, setLocalError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedFile(null)
+      setBatchId('')
+      setMashBillId('')
+      setLocalError(null)
+    }
+  }, [isOpen])
+
+  if (!isOpen) return null
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (!selectedFile) {
+      setLocalError('Please choose a CSV file to upload.')
+      return
+    }
+
+    if (requireMashBillId && mashBillId.trim() === '') {
+      setLocalError('Mash bill ID is required to create a new batch.')
+      return
+    }
+
+    const batchValue = batchId.trim() === '' ? undefined : parseInt(batchId, 10)
+    if (batchValue !== undefined && Number.isNaN(batchValue)) {
+      setLocalError('Batch ID must be a number.')
+      return
+    }
+
+    const mashBillValue = mashBillId.trim() === '' ? undefined : parseInt(mashBillId, 10)
+    if (mashBillValue !== undefined && Number.isNaN(mashBillValue)) {
+      setLocalError('Mash bill ID must be a number.')
+      return
+    }
+
+    setLocalError(null)
+
+    await onSubmit({ file: selectedFile, batchId: batchValue, mashBillId: mashBillValue })
+  }
+
+  return (
+    <div className='modal'>
+      <form onSubmit={handleSubmit} className='modal-content'>
+        <h3>Import Barrels</h3>
+        <label>
+          CSV File
+          <input
+            type='file'
+            accept='.csv'
+            onChange={event => setSelectedFile(event.target.files?.[0] ?? null)}
+          />
+        </label>
+        <label>
+          Batch ID
+          <input
+            type='number'
+            min={1}
+            placeholder='Optional'
+            value={batchId}
+            onChange={event => setBatchId(event.target.value)}
+          />
+        </label>
+        {(requireMashBillId || mashBillId) && (
+          <label>
+            Mash Bill ID
+            <input
+              type='number'
+              min={1}
+              value={mashBillId}
+              onChange={event => setMashBillId(event.target.value)}
+            />
+          </label>
+        )}
+        {(localError || error) && <p className='modal-error'>{localError ?? error}</p>}
+        <div className='modal-actions'>
+          <button type='submit'>Submit</button>
+          <button type='button' onClick={onClose}>
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/caskr.client/src/features/barrelsSlice.ts
+++ b/caskr.client/src/features/barrelsSlice.ts
@@ -36,6 +36,43 @@ export const forecastBarrels = createAsyncThunk(
   }
 )
 
+export interface BarrelImportParams {
+  companyId: number
+  file: File
+  batchId?: number
+  mashBillId?: number
+}
+
+export const importBarrels = createAsyncThunk(
+  'barrels/import',
+  async ({ companyId, file, batchId, mashBillId }: BarrelImportParams, { rejectWithValue }) => {
+    const formData = new FormData()
+    formData.append('file', file)
+    if (batchId !== undefined) {
+      formData.append('batchId', batchId.toString())
+    }
+    if (mashBillId !== undefined) {
+      formData.append('mashBillId', mashBillId.toString())
+    }
+
+    const response = await authorizedFetch(`api/barrels/company/${companyId}/import`, {
+      method: 'POST',
+      body: formData
+    })
+
+    if (!response.ok) {
+      try {
+        const error = await response.json()
+        return rejectWithValue(error)
+      } catch (err) {
+        return rejectWithValue({ message: 'Failed to import barrels' })
+      }
+    }
+
+    return (await response.json()) as { created: number; batchId: number; createdNewBatch: boolean }
+  }
+)
+
 interface BarrelsState {
   items: Barrel[]
   forecast: Barrel[]

--- a/caskr.client/src/index.css
+++ b/caskr.client/src/index.css
@@ -141,6 +141,11 @@ button:hover {
   margin-bottom: 1rem;
 }
 
+.section-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
 .section-title {
   font-size: 20px;
   font-weight: 600;
@@ -279,6 +284,12 @@ button:hover {
 }
 
 .forecast-error {
+  margin-top: 0.75rem;
+  color: var(--secondary-orange);
+  font-weight: 600;
+}
+
+.modal-error {
   margin-top: 0.75rem;
   color: var(--secondary-orange);
   font-weight: 600;

--- a/caskr.client/src/pages/BarrelsPage.tsx
+++ b/caskr.client/src/pages/BarrelsPage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../hooks'
-import { fetchBarrels, forecastBarrels } from '../features/barrelsSlice'
+import { fetchBarrels, forecastBarrels, importBarrels } from '../features/barrelsSlice'
 import ForecastingModal from '../components/ForecastingModal'
+import BarrelImportModal from '../components/BarrelImportModal'
 
 function BarrelsPage() {
   const dispatch = useAppDispatch()
@@ -9,6 +10,9 @@ function BarrelsPage() {
   const forecast = useAppSelector(state => state.barrels.forecast)
   const forecastCount = useAppSelector(state => state.barrels.forecastCount)
   const [showModal, setShowModal] = useState(false)
+  const [showImportModal, setShowImportModal] = useState(false)
+  const [requireMashBillId, setRequireMashBillId] = useState(false)
+  const [importError, setImportError] = useState<string | null>(null)
   const companyId = 1
 
   useEffect(() => {
@@ -20,17 +24,57 @@ function BarrelsPage() {
     setShowModal(false)
   }
 
+  const openImportModal = () => {
+    setRequireMashBillId(false)
+    setImportError(null)
+    setShowImportModal(true)
+  }
+
+  const handleImport = async ({ file, batchId, mashBillId }: { file: File; batchId?: number; mashBillId?: number }) => {
+    try {
+      await dispatch(importBarrels({ companyId, file, batchId, mashBillId })).unwrap()
+      setShowImportModal(false)
+      setRequireMashBillId(false)
+      setImportError(null)
+      await dispatch(fetchBarrels(companyId))
+    } catch (err) {
+      if (err && typeof err === 'object') {
+        const errorObject = err as { message?: string; requiresMashBillId?: boolean }
+        if (errorObject.requiresMashBillId) {
+          setRequireMashBillId(true)
+        }
+        setImportError(errorObject.message ?? 'Unable to import barrels. Please try again.')
+      } else {
+        setImportError('Unable to import barrels. Please try again.')
+      }
+    }
+  }
+
   return (
     <>
       <section className='content-section'>
         <div className='section-header'>
           <h2 className='section-title'>Barrels</h2>
-          <button onClick={() => setShowModal(true)}>Forecasting</button>
+          <div className='section-actions'>
+            <button onClick={() => setShowModal(true)}>Forecasting</button>
+            <button onClick={openImportModal}>Import CSV</button>
+          </div>
         </div>
         <ForecastingModal
           isOpen={showModal}
           onClose={() => setShowModal(false)}
           onSubmit={handleForecast}
+        />
+        <BarrelImportModal
+          isOpen={showImportModal}
+          requireMashBillId={requireMashBillId}
+          error={importError}
+          onClose={() => {
+            setShowImportModal(false)
+            setRequireMashBillId(false)
+            setImportError(null)
+          }}
+          onSubmit={handleImport}
         />
         <div className='table-container'>
           <table className='table'>


### PR DESCRIPTION
## Summary
- add a barrel import endpoint that parses CSV uploads, resolves rickhouses and batch information, and creates barrels
- extend barrel services/repositories plus add focused tests covering batch/order creation scenarios
- add a client CSV upload modal with mash bill fallback handling and refresh the barrels list after import

## Testing
- `dotnet restore` *(fails: dotnet not available in environment)*
- `dotnet build --no-restore` *(fails: dotnet not available in environment)*
- `dotnet test --no-build` *(fails: dotnet not available in environment)*
- `npm --prefix caskr.client test` *(fails: Chrome browser is not installed for Playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68d190679ca8832b99ddea51e9aec8f7