### PR TITLE
Update forecast messaging to include age context

### DIFF
--- a/caskr.client/src/features/barrelsSlice.ts
+++ b/caskr.client/src/features/barrelsSlice.ts
@@ -40,9 +40,17 @@ interface BarrelsState {
   items: Barrel[]
   forecast: Barrel[]
   forecastCount: number
+  forecastDate: string | null
+  forecastAgeYears: number | null
 }
 
-const initialState: BarrelsState = { items: [], forecast: [], forecastCount: 0 }
+const initialState: BarrelsState = {
+  items: [],
+  forecast: [],
+  forecastCount: 0,
+  forecastDate: null,
+  forecastAgeYears: null
+}
 
 const barrelsSlice = createSlice({
   name: 'barrels',
@@ -55,6 +63,8 @@ const barrelsSlice = createSlice({
     builder.addCase(forecastBarrels.fulfilled, (state, action) => {
       state.forecast = action.payload.barrels
       state.forecastCount = action.payload.count
+      state.forecastDate = action.meta.arg.targetDate
+      state.forecastAgeYears = action.meta.arg.ageYears
     })
   }
 })

--- a/caskr.client/src/pages/BarrelsPage.tsx
+++ b/caskr.client/src/pages/BarrelsPage.tsx
@@ -2,12 +2,15 @@ import { useEffect, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '../hooks'
 import { fetchBarrels, forecastBarrels } from '../features/barrelsSlice'
 import ForecastingModal from '../components/ForecastingModal'
+import { formatForecastSummary } from '../utils/forecastSummary'
 
 function BarrelsPage() {
   const dispatch = useAppDispatch()
   const barrels = useAppSelector(state => state.barrels.items)
   const forecast = useAppSelector(state => state.barrels.forecast)
   const forecastCount = useAppSelector(state => state.barrels.forecastCount)
+  const forecastDate = useAppSelector(state => state.barrels.forecastDate)
+  const forecastAgeYears = useAppSelector(state => state.barrels.forecastAgeYears)
   const [showModal, setShowModal] = useState(false)
   const companyId = 1
 
@@ -54,8 +57,9 @@ function BarrelsPage() {
       {forecast.length > 0 && (
         <section className='content-section'>
           <div className='section-header'>
-            <h2 className='section-title'>Forecast Result (Total: {forecastCount})</h2>
+            <h2 className='section-title'>Forecast Result</h2>
           </div>
+          <p>{formatForecastSummary(forecastDate, forecastAgeYears, forecastCount)}</p>
           <div className='table-container'>
             <table className='table'>
               <thead>

--- a/caskr.client/src/pages/DashboardPage.tsx
+++ b/caskr.client/src/pages/DashboardPage.tsx
@@ -7,6 +7,7 @@ import {
 import { fetchStatuses } from '../features/statusSlice'
 import { fetchBarrels, forecastBarrels } from '../features/barrelsSlice'
 import ForecastingModal from '../components/ForecastingModal'
+import { formatForecastSummary } from '../utils/forecastSummary'
 
 export default function DashboardPage() {
   const dispatch = useAppDispatch()
@@ -16,7 +17,9 @@ export default function DashboardPage() {
   const barrels = useAppSelector(state => state.barrels.items)
   const [showForecastModal, setShowForecastModal] = useState(false)
   const [forecastError, setForecastError] = useState<string | null>(null)
-  const [forecastResult, setForecastResult] = useState<{ date: string; count: number } | null>(null)
+  const [forecastResult, setForecastResult] = useState<
+    { date: string; count: number; ageYears: number }
+  | null>(null)
 
   useEffect(() => {
     dispatch(fetchOrders()).then(action => {
@@ -32,7 +35,7 @@ export default function DashboardPage() {
     setForecastError(null)
     try {
       const result = await dispatch(forecastBarrels({ companyId: 1, targetDate, ageYears })).unwrap()
-      setForecastResult({ date: targetDate, count: result.count })
+      setForecastResult({ date: targetDate, count: result.count, ageYears })
       setShowForecastModal(false)
     } catch (error) {
       setForecastError('Unable to forecast barrels right now. Please try again later.')
@@ -58,9 +61,7 @@ export default function DashboardPage() {
           <button onClick={() => setShowForecastModal(true)}>Open Forecasting</button>
         </div>
         {forecastResult && (
-          <p>
-            Barrels available on {new Date(forecastResult.date).toLocaleDateString()}: {forecastResult.count}
-          </p>
+          <p>{formatForecastSummary(forecastResult.date, forecastResult.ageYears, forecastResult.count)}</p>
         )}
         {forecastError && <p className='forecast-error'>{forecastError}</p>}
       </section>

--- a/caskr.client/src/utils/forecastSummary.ts
+++ b/caskr.client/src/utils/forecastSummary.ts
@@ -1,0 +1,16 @@
+export function formatForecastSummary(
+  date: string | null | undefined,
+  ageYears: number | null | undefined,
+  count: number
+): string {
+  if (!date) {
+    return ''
+  }
+
+  const formattedDate = new Date(date).toLocaleDateString()
+  const ageText = ageYears && ageYears > 0
+    ? `aged ${ageYears} ${ageYears === 1 ? 'year' : 'years'} `
+    : ''
+
+  return `Barrels ${ageText}available on ${formattedDate}: ${count}`
+}

--- a/caskr.client/tests/forecastSummary.spec.ts
+++ b/caskr.client/tests/forecastSummary.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test'
+import { formatForecastSummary } from '../src/utils/forecastSummary'
+
+test('formats forecast summary with age information', () => {
+  const message = formatForecastSummary('2025-06-01', 5, 12)
+  expect(message).toContain('Barrels aged 5 years available')
+  expect(message).toContain('12')
+})
+
+test('omits age phrase when no age is provided', () => {
+  const message = formatForecastSummary('2025-06-01', 0, 4)
+  const formattedDate = new Date('2025-06-01').toLocaleDateString()
+  expect(message).toBe(`Barrels available on ${formattedDate}: 4`)
+})


### PR DESCRIPTION
## Summary
- store the most recent forecast date and age in the barrels slice
- surface aged-barrel availability messaging on the dashboard and barrels pages via a shared formatter
- cover the formatter with new Playwright unit tests

## Testing
- dotnet restore *(fails: command not found)*
- npm --prefix caskr.client test *(fails: missing Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_68d19241c7f8832bb4e2e63b0722166b