### PR TITLE
Enable dashboard order modal

### DIFF
--- a/caskr.client/tests/dashboard.spec.ts
+++ b/caskr.client/tests/dashboard.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('dashboard active orders', () => {
+  test('opens order actions modal when clicking an active order', async ({ page }) => {
+    await page.route('**/api/status', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { id: 1, name: 'In Progress', statusTasks: [{ id: 10, name: 'Review paperwork' }] }
+        ])
+      })
+    })
+
+    await page.route('**/api/orders', async route => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([
+            { id: 1, name: 'Bourbon Order', statusId: 1, ownerId: 1, spiritTypeId: 1, quantity: 10, mashBillId: 1 }
+          ])
+        })
+      } else {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+      }
+    })
+
+    await page.route('**/api/orders/1/outstanding-tasks', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ id: 10, name: 'Review paperwork' }])
+      })
+    })
+
+    await page.route('**/api/barrels/company/1', async route => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+    })
+
+    await page.goto('/')
+
+    await page.getByRole('row', { name: /Bourbon Order/ }).click()
+
+    await expect(page.getByRole('heading', { level: 2, name: 'Bourbon Order' })).toBeVisible()
+    await expect(page.getByText('Outstanding Tasks')).toBeVisible()
+    await expect(page.getByText('Review paperwork')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
- allow clicking active orders on the dashboard to open the order actions modal
- reuse order update/delete handlers on the dashboard for consistent behavior
- add a Playwright test that verifies the dashboard opens the modal when an order row is clicked

## Testing
- dotnet restore *(fails: `dotnet` not installed in container)*
- dotnet build --no-restore *(fails: `dotnet` not installed in container)*
- dotnet test --no-build *(fails: `dotnet` not installed in container)*
- npm --prefix caskr.client test *(fails: Chromium `chrome` build not installed; Playwright suggests `npx playwright install chrome`)*

------
https://chatgpt.com/codex/tasks/task_e_68d19abd7a54832b896ae9842ddd6c92