### PR TITLE
Fix document download and add coverage

### DIFF
--- a/caskr.client/src/components/LabelModal.tsx
+++ b/caskr.client/src/components/LabelModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useAppSelector } from '../hooks'
 import { authorizedFetch } from '../api/authorizedFetch'
+import { downloadBlob } from '../utils/downloadBlob'
 import './CreateOrderModal.css'
 
 type Props = {
@@ -34,13 +35,11 @@ const LabelModal = ({ isOpen, onClose, orderName }: Props) => {
         alcoholContent
       })
     })
+    if (!response.ok) {
+      throw new Error('Failed to generate label document')
+    }
     const blob = await response.blob()
-    const url = window.URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'ttb_form_5100_31.pdf'
-    a.click()
-    window.URL.revokeObjectURL(url)
+    downloadBlob(blob, 'ttb_form_5100_31.pdf')
     onClose()
     setBrandName('')
     setProductName('')

--- a/caskr.client/src/components/TransferModal.tsx
+++ b/caskr.client/src/components/TransferModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useAppSelector } from '../hooks'
 import { authorizedFetch } from '../api/authorizedFetch'
+import { downloadBlob } from '../utils/downloadBlob'
 import './CreateOrderModal.css'
 
 type Props = {
@@ -29,13 +30,11 @@ const TransferModal = ({ isOpen, onClose }: Props) => {
         barrelCount
       })
     })
+    if (!response.ok) {
+      throw new Error('Failed to generate transfer document')
+    }
     const blob = await response.blob()
-    const url = window.URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'ttb_form_5100_16.pdf'
-    a.click()
-    window.URL.revokeObjectURL(url)
+    downloadBlob(blob, 'ttb_form_5100_16.pdf')
     onClose()
     setToCompanyName('')
     setPermitNumber('')

--- a/caskr.client/src/utils/downloadBlob.ts
+++ b/caskr.client/src/utils/downloadBlob.ts
@@ -1,0 +1,13 @@
+export const downloadBlob = (blob: Blob, filename: string) => {
+  const url = window.URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  anchor.style.display = 'none'
+  document.body.appendChild(anchor)
+  anchor.click()
+  document.body.removeChild(anchor)
+  window.setTimeout(() => {
+    window.URL.revokeObjectURL(url)
+  })
+}

--- a/caskr.client/tests/labelDownload.spec.ts
+++ b/caskr.client/tests/labelDownload.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@playwright/test'
+
+const mockOrders = [
+  { id: 1, name: 'TTB Filing Order', statusId: 2, ownerId: 1, spiritTypeId: 1, quantity: 10, mashBillId: 1 }
+]
+
+const mockStatuses = [
+  { id: 2, name: 'Awaiting TTB Approval', statusTasks: [] }
+]
+
+test.describe('label document generation', () => {
+  test('downloads the generated TTB PDF', async ({ page }) => {
+    await page.route('**/api/status', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockStatuses)
+      })
+    })
+
+    await page.route('**/api/orders', async route => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(mockOrders)
+        })
+      } else {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+      }
+    })
+
+    await page.route('**/api/orders/1/outstanding-tasks', async route => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+    })
+
+    const pdfContent = '%PDF-1.4\n%Mock PDF content\n'
+    await page.route('**/api/labels/ttb-form', async route => {
+      expect(route.request().method()).toBe('POST')
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'Content-Type': 'application/pdf'
+        },
+        body: pdfContent
+      })
+    })
+
+    await page.goto('/orders')
+
+    await page.getByRole('row', { name: /TTB Filing Order/ }).click()
+    await page.getByRole('button', { name: 'Generate TTB Document' }).click()
+
+    await page.fill('input[placeholder="Brand Name"]', 'Mock Brand')
+    await page.fill('input[placeholder="Product Name"]', 'Mock Product')
+    await page.fill('input[placeholder="Alcohol Content"]', '40%')
+
+    const downloadPromise = page.waitForEvent('download')
+    await page.getByRole('button', { name: 'Generate' }).click()
+    const download = await downloadPromise
+
+    expect(download.suggestedFilename()).toBe('ttb_form_5100_31.pdf')
+
+    const stream = await download.createReadStream()
+    if (!stream) {
+      throw new Error('Expected download stream to be available')
+    }
+    const chunks: Buffer[] = []
+    for await (const chunk of stream) {
+      chunks.push(Buffer.from(chunk))
+    }
+    const downloadedContent = Buffer.concat(chunks).toString()
+    expect(downloadedContent).toBe(pdfContent)
+  })
+})


### PR DESCRIPTION
## Summary
- ensure generated TTB documents trigger a download by delegating to a shared helper that appends the link to the DOM before clicking
- add explicit error handling for failed label and transfer document generation requests
- cover the regression with a Playwright test that verifies the generated PDF is downloaded from the orders flow

## Testing
- npm --prefix caskr.client test *(fails: chromium distribution 'chrome' is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d19fb0928c832bb7c68e2b9aa826cc