### PR TITLE
Add global loading spinner tied to authorized fetch

### DIFF
--- a/caskr.client/src/api/authorizedFetch.ts
+++ b/caskr.client/src/api/authorizedFetch.ts
@@ -1,3 +1,5 @@
+import { loadingManager } from '../loadingManager'
+
 export const authorizedFetch = async (input: RequestInfo | URL, init: RequestInit = {}) => {
   const token = localStorage.getItem('token')
   const headers = new Headers(init.headers ?? {})
@@ -6,5 +8,10 @@ export const authorizedFetch = async (input: RequestInfo | URL, init: RequestIni
     headers.set('Authorization', `Bearer ${token}`)
   }
 
-  return fetch(input, { ...init, headers })
+  loadingManager.beginRequest()
+  try {
+    return await fetch(input, { ...init, headers })
+  } finally {
+    loadingManager.endRequest()
+  }
 }

--- a/caskr.client/src/components/Layout.tsx
+++ b/caskr.client/src/components/Layout.tsx
@@ -1,8 +1,10 @@
 import { Link, Outlet } from 'react-router-dom'
+import LoadingOverlay from './LoadingOverlay'
 
 export default function Layout() {
   return (
     <>
+      <LoadingOverlay />
       <header className='header'>
         <div className='header-content'>
           <Link to='/' className='logo'>

--- a/caskr.client/src/components/LoadingOverlay.tsx
+++ b/caskr.client/src/components/LoadingOverlay.tsx
@@ -1,0 +1,21 @@
+import { useSyncExternalStore } from 'react'
+import { loadingManager } from '../loadingManager'
+
+export default function LoadingOverlay() {
+  const isLoading = useSyncExternalStore(
+    loadingManager.subscribe,
+    loadingManager.getSnapshot,
+    loadingManager.getServerSnapshot
+  )
+
+  if (!isLoading) return null
+
+  return (
+    <div className='loading-overlay' aria-live='polite'>
+      <div className='loading-spinner' role='status' aria-label='Loading'>
+        <span className='visually-hidden'>Loading</span>
+      </div>
+    </div>
+  )
+}
+

--- a/caskr.client/src/index.css
+++ b/caskr.client/src/index.css
@@ -200,6 +200,48 @@ button:hover {
   transition: background 0.2s ease-in-out;
 }
 
+.loading-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.loading-spinner {
+  width: 3.5rem;
+  height: 3.5rem;
+  border: 4px solid rgba(255, 255, 255, 0.6);
+  border-top-color: var(--primary-blue);
+  border-radius: 50%;
+  animation: loading-spin 1s linear infinite;
+  background: rgba(255, 255, 255, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .table tbody tr.clickable-row:hover {
   background: var(--gray-100);
 }

--- a/caskr.client/src/loadingManager.ts
+++ b/caskr.client/src/loadingManager.ts
@@ -1,0 +1,34 @@
+type Listener = () => void
+
+let activeRequests = 0
+const listeners = new Set<Listener>()
+
+const notifyListeners = () => {
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+export const loadingManager = {
+  beginRequest() {
+    activeRequests += 1
+    notifyListeners()
+  },
+  endRequest() {
+    activeRequests = Math.max(0, activeRequests - 1)
+    notifyListeners()
+  },
+  subscribe(listener: Listener) {
+    listeners.add(listener)
+    return () => {
+      listeners.delete(listener)
+    }
+  },
+  getSnapshot() {
+    return activeRequests > 0
+  },
+  getServerSnapshot() {
+    return false
+  }
+}
+

--- a/caskr.client/tests/loadingSpinner.spec.ts
+++ b/caskr.client/tests/loadingSpinner.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('global loading spinner', () => {
+  test('appears while fetch requests are in flight', async ({ page }) => {
+    await page.route('**/api/status', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ id: 1, name: 'New', statusTasks: [] }])
+      })
+    );
+
+    await page.route('**/api/orders', async route => {
+      if (route.request().method() === 'GET') {
+        await new Promise(resolve => setTimeout(resolve, 500));
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+      } else {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+      }
+    });
+
+    await page.goto('/orders');
+
+    const spinner = page.getByRole('status', { name: 'Loading' });
+    await expect(spinner).toBeVisible();
+    await expect(spinner).toBeHidden();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add a loading manager that tracks authorized fetch activity across the app
- render a reusable loading overlay so users see a spinner during pending requests
- cover the overlay behaviour with a Playwright test that delays API responses

## Testing
- dotnet restore *(fails: `dotnet` command not found in container)*
- dotnet build --no-restore *(fails: `dotnet` command not found in container)*
- dotnet test --no-build *(fails: `dotnet` command not found in container)*
- npm --prefix caskr.client test *(fails: Chromium distribution 'chrome' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a1c97b40832bb365cb5bd607a8ab