### PR TITLE
Fix label modal request content type

### DIFF
--- a/caskr.client/src/components/LabelModal.tsx
+++ b/caskr.client/src/components/LabelModal.tsx
@@ -27,7 +27,7 @@ const LabelModal = ({ isOpen, onClose, orderName }: Props) => {
     if (!user) return
     const response = await authorizedFetch('/api/labels/ttb-form', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/pdf' },
+      headers: { 'Content-Type': 'application/json', Accept: 'application/pdf' },
       body: JSON.stringify({
         companyId: user.companyId,
         brandName,

--- a/caskr.client/tests/labelDownload.spec.ts
+++ b/caskr.client/tests/labelDownload.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import type { Page } from '@playwright/test'
 
 const mockOrders = [
   { id: 1, name: 'TTB Filing Order', statusId: 2, ownerId: 1, spiritTypeId: 1, quantity: 10, mashBillId: 1 }
@@ -8,31 +9,35 @@ const mockStatuses = [
   { id: 2, name: 'Awaiting TTB Approval', statusTasks: [] }
 ]
 
-test.describe('label document generation', () => {
-  test('downloads the generated TTB PDF', async ({ page }) => {
-    await page.route('**/api/status', async route => {
+const setupOrdersPageRoutes = async (page: Page) => {
+  await page.route('**/api/status', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mockStatuses)
+    })
+  })
+
+  await page.route('**/api/orders', async route => {
+    if (route.request().method() === 'GET') {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(mockStatuses)
+        body: JSON.stringify(mockOrders)
       })
-    })
+    } else {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    }
+  })
 
-    await page.route('**/api/orders', async route => {
-      if (route.request().method() === 'GET') {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify(mockOrders)
-        })
-      } else {
-        await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
-      }
-    })
+  await page.route('**/api/orders/1/outstanding-tasks', async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  })
+}
 
-    await page.route('**/api/orders/1/outstanding-tasks', async route => {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
-    })
+test.describe('label document generation', () => {
+  test('downloads the generated TTB PDF', async ({ page }) => {
+    await setupOrdersPageRoutes(page)
 
     const pdfContent = '%PDF-1.4\n%Mock PDF content\n'
     await page.route('**/api/labels/ttb-form', async route => {
@@ -71,5 +76,53 @@ test.describe('label document generation', () => {
     }
     const downloadedContent = Buffer.concat(chunks).toString()
     expect(downloadedContent).toBe(pdfContent)
+  })
+
+  test('sends label generation requests as JSON', async ({ page }) => {
+    await setupOrdersPageRoutes(page)
+
+    const pdfContent = '%PDF-1.4\n%Mock PDF content\n'
+    let capturedContentType: string | null = null
+    let capturedAccept: string | null = null
+    let capturedBody: string | null = null
+
+    await page.route('**/api/labels/ttb-form', async route => {
+      const request = route.request()
+      capturedContentType = request.headerValue('content-type')
+      capturedAccept = request.headerValue('accept')
+      capturedBody = request.postData() ?? null
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'Content-Type': 'application/pdf'
+        },
+        body: pdfContent
+      })
+    })
+
+    await page.goto('/orders')
+
+    await page.getByRole('row', { name: /TTB Filing Order/ }).click()
+    await page.getByRole('button', { name: 'Generate TTB Document' }).click()
+
+    await page.fill('input[placeholder="Brand Name"]', 'Mock Brand')
+    await page.fill('input[placeholder="Product Name"]', 'Mock Product')
+    await page.fill('input[placeholder="Alcohol Content"]', '40%')
+
+    const downloadPromise = page.waitForEvent('download')
+    await page.getByRole('button', { name: 'Generate' }).click()
+    await downloadPromise
+
+    expect(capturedContentType).toBe('application/json')
+    expect(capturedAccept).toBe('application/pdf')
+    expect(capturedBody).not.toBeNull()
+
+    const payload = JSON.parse(capturedBody!)
+    expect(payload).toMatchObject({
+      brandName: 'Mock Brand',
+      productName: 'Mock Product',
+      alcoholContent: '40%'
+    })
+    expect(typeof payload.companyId).toBe('number')
   })
 })


### PR DESCRIPTION
## Summary
- send label generation requests as JSON and request a PDF response
- refactor the Playwright label test setup and add coverage for the JSON payload and headers

## Testing
- dotnet restore *(fails: `dotnet: command not found`)*
- dotnet build --no-restore *(fails: `dotnet: command not found`)*
- dotnet test --no-build *(fails: `dotnet: command not found`)*
- npm --prefix caskr.client test *(fails: Chromium distribution 'chrome' is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a9552540832bbe9af930fc4ed2ce